### PR TITLE
 Makefile: Add "install" target to install host-side files. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,4 @@ clean:
 install:
 	sudo cp contrib/LAVA.rules /etc/udev/rules.d/
 	sudo cp contrib/usb-passthrough /usr/local/bin/
+	sudo udevadm control --reload

--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,7 @@ all:
 clean:
 	docker-compose rm -vsf
 	docker volume rm -f lava-server-pgdata lava-server-joboutput lava-server-devices lava-server-health-checks
+
+install:
+	sudo cp contrib/LAVA.rules /etc/udev/rules.d/
+	sudo cp contrib/usb-passthrough /usr/local/bin/


### PR DESCRIPTION
Like, udev rules and usb passthru script.

For udev rules, the idea is that a user will update repo's template with their
board serial number first.