### PR TITLE
docker-compose.yaml: Add overlays for OpenOCD boot action method

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
     - ./overlays/lava-server/etc/lava-server/instance.conf:/etc/lava-server/instance.conf:ro
     - ./overlays/lava-server/etc/lava-server/settings.conf:/etc/lava-server/settings.conf:ro
     - ./overlays/lava-server/etc/lava-server/lava-logs:/etc/lava-server/lava-logs:ro
+    - ./overlays/lava-common/usr/lib/python3/dist-packages/lava_common/utils.py:/usr/lib/python3/dist-packages/lava_common/utils.py:ro
     depends_on:
     - db
     environment:
@@ -37,6 +38,9 @@ services:
     - ./overlays/lava-server/etc/lava-server/settings.conf:/etc/lava-server/settings.conf:ro
     - ./overlays/lava-server/etc/lava-server/lava-master:/etc/lava-server/lava-master:ro
     - ./overlays/lava-server/etc/lava-server/dispatcher-config/device-types/frdm-k64f.jinja2:/etc/lava-server/dispatcher-config/device-types/frdm-k64f.jinja2:ro
+    - ./overlays/lava-common/usr/lib/python3/dist-packages/lava_common/utils.py:/usr/lib/python3/dist-packages/lava_common/utils.py:ro
+    - ./overlays/lava-server/etc/lava-server/dispatcher-config/device-types/cc3220SF.jinja2:/etc/lava-server/dispatcher-config/device-types/cc3220SF.jinja2:ro
+    - ./overlays/lava-common/usr/lib/python3/dist-packages/lava_common/schemas/boot/openocd.py:/usr/lib/python3/dist-packages/lava_common/schemas/boot/openocd.py:ro
     depends_on:
     - db
     environment:
@@ -51,6 +55,9 @@ services:
     volumes:
     - ./overlays/lava-server/etc/lava-server/instance.conf:/etc/lava-server/instance.conf:ro
     - ./overlays/lava-publisher/etc/lava-server/settings.conf:/etc/lava-server/settings.conf:ro
+    - ./overlays/lava-common/usr/lib/python3/dist-packages/lava_common/utils.py:/usr/lib/python3/dist-packages/lava_common/utils.py:ro
+    - ./overlays/lava-server/etc/lava-server/dispatcher-config/device-types/cc3220SF.jinja2:/etc/lava-server/dispatcher-config/device-types/cc3220SF.jinja2:ro
+    - ./overlays/lava-common/usr/lib/python3/dist-packages/lava_common/schemas/boot/openocd.py:/usr/lib/python3/dist-packages/lava_common/schemas/boot/openocd.py:ro
     environment:
       SERVICES: "lava-publisher"
     ports:
@@ -67,6 +74,7 @@ services:
     - ./overlays/lava-server/etc/lava-server/instance.conf:/etc/lava-server/instance.conf:ro
     - ./overlays/lava-server/etc/lava-server/settings.conf:/etc/lava-server/settings.conf:ro
     - ./overlays/lava-server/etc/lava-server/dispatcher-config/device-types/frdm-k64f.jinja2:/etc/lava-server/dispatcher-config/device-types/frdm-k64f.jinja2:ro
+    - ./overlays/lava-server/etc/lava-server/dispatcher-config/device-types/cc3220SF.jinja2:/etc/lava-server/dispatcher-config/device-types/cc3220SF.jinja2:ro
     depends_on:
     - db
     environment:
@@ -111,6 +119,10 @@ services:
     - /boot:/boot:ro
     - /lib/modules:/lib/modules:ro
     - ./overlays/lava-dispatcher/usr/lib/python3/dist-packages/lava_dispatcher/actions/boot/pyocd.py:/usr/lib/python3/dist-packages/lava_dispatcher/actions/boot/pyocd.py:ro
+    - ./overlays/lava-common/usr/lib/python3/dist-packages/lava_common/utils.py:/usr/lib/python3/dist-packages/lava_common/utils.py:ro
+    - ./overlays/lava-common/usr/lib/python3/dist-packages/lava_common/schemas/boot/openocd.py:/usr/lib/python3/dist-packages/lava_common/schemas/boot/openocd.py:ro
+    - ./overlays/lava-dispatcher/usr/lib/python3/dist-packages/lava_dispatcher/actions/boot/openocd.py:/usr/lib/python3/dist-packages/lava_dispatcher/actions/boot/openocd.py:ro
+    - ./overlays/lava-dispatcher/usr/lib/python3/dist-packages/lava_dispatcher/actions/boot/strategies.py:/usr/lib/python3/dist-packages/lava_dispatcher/actions/boot/strategies.py:ro
       # Example for development
       # If you wanted to point to a local git checkout of lava for development
       # of lava_dispatcher, you can uncomment out the lines below and

--- a/overlays/lava-common/usr/lib/python3/dist-packages/lava_common/schemas/boot/openocd.py
+++ b/overlays/lava-common/usr/lib/python3/dist-packages/lava_common/schemas/boot/openocd.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 Linaro Limited
+#
+# Author: Vincent Wan <vincent.wan@linaro.org>
+#
+# This file is part of LAVA.
+#
+# LAVA is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# LAVA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along
+# with this program; if not, see <http://www.gnu.org/licenses>.
+
+from voluptuous import Msg, Required
+
+from lava_common.schemas import boot
+
+
+def schema():
+    base = {Required("method"): Msg("openocd", "'method' should be 'openocd'")}
+    return {**boot.schema(), **base}

--- a/overlays/lava-common/usr/lib/python3/dist-packages/lava_common/utils.py
+++ b/overlays/lava-common/usr/lib/python3/dist-packages/lava_common/utils.py
@@ -1,0 +1,114 @@
+# Copyright (C) 2018 Linaro Limited
+#
+# Author: Remi Duraffort <remi.duraffort@linaro.org>
+#
+# This file is part of LAVA.
+#
+# LAVA is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# LAVA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along
+# with this program; if not, see <http://www.gnu.org/licenses>.
+
+import re
+import contextlib
+import subprocess  # nosec dpkg
+from lava_common.exceptions import InfrastructureError
+
+
+def binary_version(binary, flags="", pattern=""):
+    """
+    Returns a string with the version of the binary by running it with
+    the provided flags. If the output from running the binary is verbose
+    and contains more than just the version number, a pattern can be
+    provided for the function to parse the output to pick out the
+    substring that contains the version number.
+    """
+    # if binary is not absolute, fail.
+    msg = "Unable to retrieve version of %s" % binary
+    try:
+        ver_str = (
+            subprocess.check_output((binary, flags), stderr=subprocess.STDOUT)
+            .strip()
+            .decode("utf-8", errors="replace")
+        )
+        if not ver_str:
+            raise InfrastructureError(msg)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        raise InfrastructureError(msg)
+
+    if pattern is not "":
+        p = re.compile(pattern)
+        result = p.search(ver_str)
+        if result is not None:
+            ver_str = result.group(1)
+        else:
+            raise InfrastructureError(msg)
+
+    return "%s, version %s" % (binary, ver_str)
+
+
+def debian_package_arch(pkg):
+    """
+    Relies on Debian Policy rules for the existence of the
+    changelog. Distributions not derived from Debian will
+    return an empty string.
+    """
+    with contextlib.suppress(FileNotFoundError, subprocess.CalledProcessError):
+        return (
+            subprocess.check_output(  # nosec dpkg-query
+                ("dpkg-query", "-W", "-f=${Architecture}\n", "%s" % pkg)
+            )
+            .strip()
+            .decode("utf-8", errors="replace")
+        )
+    return ""
+
+
+def debian_package_version(pkg):
+    """
+    Use dpkg-query to retrive the version of the given package.
+    Distributions not derived from Debian will return an empty string.
+    """
+    with contextlib.suppress(FileNotFoundError, subprocess.CalledProcessError):
+        return (
+            subprocess.check_output(  # nosec dpkg-query
+                ("dpkg-query", "-W", "-f=${Version}\n", "%s" % pkg)
+            )
+            .strip()
+            .decode("utf-8", errors="replace")
+        )
+    return ""
+
+
+def debian_filename_version(binary, label=False):
+    """
+    Relies on Debian Policy rules for the existence of the
+    changelog. Distributions not derived from Debian will
+    return an empty string.
+    """
+    # if binary is not absolute, fail.
+    msg = "Unable to retrieve version of %s" % binary
+    try:
+        pkg_str = (
+            subprocess.check_output(("dpkg-query", "-S", binary))  # nosec dpkg-query
+            .strip()
+            .decode("utf-8", errors="replace")
+        )
+        if not pkg_str:
+            raise InfrastructureError(msg)
+    except subprocess.CalledProcessError:
+        raise InfrastructureError(msg)
+    pkg = pkg_str.split(":")[0]
+    pkg_ver = debian_package_version(pkg)
+    if not label:
+        return pkg_ver
+    return "%s for <%s>, installed at version: %s" % (pkg, binary, pkg_ver)

--- a/overlays/lava-dispatcher/usr/lib/python3/dist-packages/lava_dispatcher/actions/boot/openocd.py
+++ b/overlays/lava-dispatcher/usr/lib/python3/dist-packages/lava_dispatcher/actions/boot/openocd.py
@@ -1,0 +1,162 @@
+# Copyright (C) 2019 Linaro Limited
+#
+# Author: Vincent Wan <vincent.wan@linaro.org>
+#
+# This file is part of LAVA Dispatcher.
+#
+# LAVA Dispatcher is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# LAVA Dispatcher is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along
+# with this program; if not, see <http://www.gnu.org/licenses>.
+
+from lava_common.utils import binary_version
+from lava_dispatcher.action import Pipeline, Action
+from lava_dispatcher.logical import Boot, RetryAction
+from lava_dispatcher.actions.boot import BootAction
+from lava_dispatcher.connections.serial import ConnectDevice
+from lava_dispatcher.utils.shell import which
+from lava_dispatcher.utils.strings import substitute
+from lava_dispatcher.power import ResetDevice
+from lava_dispatcher.utils.udev import WaitDeviceBoardID
+
+
+class OpenOCD(Boot):
+
+    compatibility = 4  # FIXME: change this to 5 and update test cases
+
+    def __init__(self, parent, parameters):
+        super().__init__(parent)
+        self.action = BootOpenOCD()
+        self.action.section = self.action_type
+        self.action.job = self.job
+        parent.add_action(self.action, parameters)
+
+    @classmethod
+    def accepts(cls, device, parameters):
+        if "openocd" not in device["actions"]["boot"]["methods"]:
+            return False, '"openocd" was not in the device configuration boot methods'
+        if "method" not in parameters:
+            return False, '"method" was not in parameters'
+        if parameters["method"] != "openocd":
+            return False, '"method" was not "openocd"'
+        if "board_id" not in device:
+            return False, '"board_id" is not in the device configuration'
+        return True, "accepted"
+
+
+class BootOpenOCD(BootAction):
+
+    name = "boot-openocd-image"
+    description = "boot openocd image with retry"
+    summary = "boot openocd image with retry"
+
+    def populate(self, parameters):
+        self.internal_pipeline = Pipeline(
+            parent=self, job=self.job, parameters=parameters
+        )
+        self.internal_pipeline.add_action(BootOpenOCDRetry())
+
+
+class BootOpenOCDRetry(RetryAction):
+
+    name = "boot-openocd-image"
+    description = "boot openocd image using the command line interface"
+    summary = "boot openocd image"
+
+    def populate(self, parameters):
+        self.internal_pipeline = Pipeline(
+            parent=self, job=self.job, parameters=parameters
+        )
+        if self.job.device.hard_reset_command:
+            self.internal_pipeline.add_action(ResetDevice())
+            self.internal_pipeline.add_action(
+                WaitDeviceBoardID(self.job.device.get("board_id"))
+            )
+        self.internal_pipeline.add_action(FlashOpenOCDAction())
+        self.internal_pipeline.add_action(ConnectDevice())
+
+
+class FlashOpenOCDAction(Action):
+
+    name = "flash-openocd"
+    description = "use openocd to flash the image"
+    summary = "use openocd to flash the image"
+
+    def __init__(self):
+        super().__init__()
+        self.base_command = []
+        self.exec_list = []
+
+    def validate(self):
+        super().validate()
+        boot = self.job.device["actions"]["boot"]["methods"]["openocd"]
+        openocd_binary = boot["parameters"]["command"]
+        binary = which(openocd_binary)
+        self.logger.info(
+            binary_version(binary, "--version", "Open On-Chip Debugger (.*)")
+        )
+        self.base_command = [openocd_binary]
+        job_cfg_file = ""
+
+        # Build the substitutions dictionary and set cfg script based on
+        # job definition
+        substitutions = {}
+        for action in self.get_namespace_keys("download-action"):
+            filename = self.get_namespace_data(
+                action="download-action", label=action, key="file"
+            )
+            if filename is None:
+                self.logger.warning(
+                    "Empty value for action='download-action' label='%s' " "key='file'",
+                    action,
+                )
+                continue
+            if action == "openocd_script":
+                # if a url for openocd_script is specified in the job
+                # definition, use that instead of the default for the device
+                # type.
+                job_cfg_file = filename
+                self.base_command.extend(["-f", job_cfg_file])
+            else:
+                substitutions["{%s}" % action.upper()] = filename
+
+        if job_cfg_file is "":
+            for item in boot["parameters"]["options"].get("file", []):
+                if item is not None:
+                    self.base_command.extend(["-f", item])
+        debug = boot["parameters"]["options"]["debug"]
+        if debug is not None:
+            self.base_command.extend(["-d" + str(debug)])
+        for item in boot["parameters"]["options"].get("search", []):
+            self.base_command.extend(["-s", item])
+        for item in boot["parameters"]["options"].get("command", []):
+            self.base_command.extend(["-c", item])
+
+        if self.job.device["board_id"] == "00000000":
+            self.errors = "[FLASH_OPENOCD] board_id unset"
+
+        self.base_command = substitute(self.base_command, substitutions)
+        self.exec_list.append(self.base_command)
+        if not self.exec_list:
+            self.errors = "No OpenOCD command to execute"
+
+    def run(self, connection, max_end_time):
+        connection = self.get_namespace_data(
+            action="shared", label="shared", key="connection", deepcopy=False
+        )
+        connection = super().run(connection, max_end_time)
+        for openocd_command in self.exec_list:
+            self.run_cmd(openocd_command)
+        self.set_namespace_data(
+            action="shared", label="shared", key="connection", value=connection
+        )
+        return connection

--- a/overlays/lava-dispatcher/usr/lib/python3/dist-packages/lava_dispatcher/actions/boot/strategies.py
+++ b/overlays/lava-dispatcher/usr/lib/python3/dist-packages/lava_dispatcher/actions/boot/strategies.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2014 Linaro Limited
+#
+# Author: Neil Williams <neil.williams@linaro.org>
+#
+# This file is part of LAVA Dispatcher.
+#
+# LAVA Dispatcher is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# LAVA Dispatcher is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along
+# with this program; if not, see <http://www.gnu.org/licenses>.
+
+# List just the subclasses supported for this base strategy
+# imported by the parser to populate the list of subclasses.
+
+# pylint: disable=unused-import
+
+from lava_dispatcher.actions.boot import SecondaryShell
+from lava_dispatcher.actions.boot.bootloader import BootBootloader
+from lava_dispatcher.actions.boot.cmsis_dap import CMSIS
+from lava_dispatcher.actions.boot.depthcharge import Depthcharge
+from lava_dispatcher.actions.boot.dfu import DFU
+from lava_dispatcher.actions.boot.docker import BootDocker
+from lava_dispatcher.actions.boot.fastboot import BootFastboot
+from lava_dispatcher.actions.boot.gdb import GDB
+from lava_dispatcher.actions.boot.grub import Grub, GrubSequence
+from lava_dispatcher.actions.boot.iso import BootIsoInstaller
+from lava_dispatcher.actions.boot.ipxe import IPXE
+from lava_dispatcher.actions.boot.kexec import BootKExec
+from lava_dispatcher.actions.boot.lxc import BootLxc
+from lava_dispatcher.actions.boot.minimal import Minimal
+from lava_dispatcher.actions.boot.openocd import OpenOCD
+from lava_dispatcher.actions.boot.pyocd import PyOCD
+from lava_dispatcher.actions.boot.qemu import BootQEMU
+from lava_dispatcher.actions.boot.ssh import SshLogin, Schroot
+from lava_dispatcher.actions.boot.u_boot import UBoot
+from lava_dispatcher.actions.boot.barebox import Barebox
+from lava_dispatcher.actions.boot.uefi import UefiShell
+from lava_dispatcher.actions.boot.uefi_menu import UefiMenu
+from lava_dispatcher.actions.boot.recovery import RecoveryBoot

--- a/overlays/lava-server/etc/lava-server/dispatcher-config/device-types/cc3220SF.jinja2
+++ b/overlays/lava-server/etc/lava-server/dispatcher-config/device-types/cc3220SF.jinja2
@@ -1,0 +1,58 @@
+{# device_type: cc3220SF #}
+{% extends 'base.jinja2' %}
+{% block body %}
+board_id: '{{ board_id|default('00000000') }}'
+usb_vendor_id: '0451'
+usb_product_id: 'bef3'
+usb_sleep: {{ usb_sleep|default(10) }}
+
+actions:
+  deploy:
+    methods:
+      image:
+        parameters:
+
+  boot:
+    connections:
+      serial:
+    methods:
+      openocd:
+        parameters:
+          command:
+            # Can set 'openocd_bin_override' in device dictionary to
+            # override location of OpenOCD executable to point to TI OpenOCD
+            # if necessary
+            {{ openocd_bin_override|default('openocd') }}
+          options:
+            file:
+              - board/ti_cc3220sf_launchpad.cfg
+            # Set 'openocd_scripts_dir_override' in device dictionary to
+            # point to TI OpenOCD scripts if necessary
+            search: [{{ openocd_scripts_dir_override }}]
+            command:
+              - init
+              - targets
+              - 'reset halt'
+              - 'flash write_image erase {BINARY}'
+              - 'reset halt'
+              - 'verify_image {BINARY}'
+              - 'reset run'
+              - shutdown
+            debug: 2
+      gdb:
+        parameters:
+          command: gdb-multiarch
+          wait_before_continue: {{ wait_before_continue|default(5) }}
+        openocd:
+          arguments:
+          - "{ZEPHYR}"
+          commands:
+          - target remote | openocd -c "gdb_port pipe" -f {OPENOCD_SCRIPT}
+          - monitor reset halt
+          - load
+          - set remotetimeout 10000
+          docker:
+            use: {{ docker_use|default(False) }}
+            container: '{{ docker_container|default('ti-openocd') }}'
+            devices: {{ docker_devices|default([]) }}
+{% endblock body %}


### PR DESCRIPTION
This commit adds the OpenOCD boot action method as an overlay temporarily
til the change is merged into upstream LAVA.

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>