### PR TITLE
Makefile: Add explicit "stop" target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ LAVA_IDENTITY = dispatcher
 all:
 	docker-compose up
 
+stop:
+	-sudo pkill udev-forward.py
+	docker-compose stop
+
 clean:
 	docker-compose rm -vsf
 	docker volume rm -f lava-server-pgdata lava-server-joboutput lava-server-devices lava-server-health-checks


### PR DESCRIPTION
Now that there's a need to stop udev-forward in addition to docker-compose.