### PR TITLE
Add musca_a device type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,5 +50,8 @@ lava-boards:
 	-lavacli -i $(LAVA_IDENTITY) devices add --type qemu --worker lava-dispatcher qemu-01
 	lavacli -i $(LAVA_IDENTITY) devices dict set qemu-01 devices/qemu-01.jinja2
 
+	-lavacli -i $(LAVA_IDENTITY) device-types add musca_a
+	lavacli -i $(LAVA_IDENTITY) device-types template set musca_a device-types/musca_a.jinja2
+
 testjob:
 	lavacli -i dispatcher jobs submit example/lava.job

--- a/device-types/musca_a.jinja2
+++ b/device-types/musca_a.jinja2
@@ -1,0 +1,36 @@
+{# device_type: musca_a #}
+{% extends 'base.jinja2' %}
+{% block body %}
+board_id: '{{ board_id|default('0000000000') }}'
+usb_vendor_id: '0d28'
+usb_product_id: '0204'
+
+actions:
+  deploy:
+    connections:
+      lxc:
+    methods:
+      lxc:
+      image:
+        parameters:
+
+  boot:
+    connections:
+      serial:
+      lxc:
+      ssh:
+    methods:
+      lxc:
+      pyocd:
+        parameters:
+          command:
+            pyocd-flashtool
+          options:
+          - -d {{ debug|default('debug') }}
+          - -t musca_a1
+          - -f 3000000
+      cmsis-dap:
+        parameters:
+          usb_mass_device: '{{ usb_mass_device|default('/notset') }}'
+          resets_after_flash: {{ resets_after_flash|default(True) }}
+{% endblock body -%}


### PR DESCRIPTION
This PR is supposed to supercede https://github.com/Linaro/lite-lava-docker-compose/pull/18 and lay the process for adding new device types to our setup in scalable manner.
