### PR TITLE
Makefile: Add "board-configs" target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,17 @@ clean:
 	docker-compose rm -vsf
 	docker volume rm -f lava-server-pgdata lava-server-joboutput lava-server-devices lava-server-health-checks
 
+# Create various board configs for connected board(s). Supposed to be done
+# before "install" target.
+board-configs:
+	@echo "Note: you should have *all* of your boards connected to USB before running this."
+	@echo "Press Ctrl+C to break if not. Review results carefully afterwards."
+	@read dummy
+	-mv ser2net/ser2net.conf ser2net/ser2net.conf.old
+	touch ser2net/ser2net.conf
+	@echo
+	contrib/make-board-files.sh devices
+
 install:
 	sudo cp contrib/LAVA.rules /etc/udev/rules.d/
 	sudo cp contrib/usb-passthrough /usr/local/bin/

--- a/contrib/make-board-files.sh
+++ b/contrib/make-board-files.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <devices_dir>"
+    exit 1
+fi
+
+for ser in $1/*.serial; do
+    echo "Processing: $ser"
+    devname=$(basename $ser .serial)
+    devtype=$(echo $devname | python -c "import sys; print(sys.stdin.readline().rsplit('-', 1)[0])")
+    contrib/board-setup-helper.py -d $(cat $ser) -t $devtype -b $1/$devname.jinja2 -u >contrib/LAVA.rules
+done


### PR DESCRIPTION
Based on board serials, stored in devices/<devname>.serial, create any
needed board configs, using board-setup-helper.py. The boards should be
connected to USB while running this.