### PR TITLE
Makefile: Add "build" target to prepare for and build docker-compose …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ board-configs:
 	@echo
 	contrib/make-board-files.sh devices
 
+# Make any preparation steps (currently none) and build docker-compose images.
+build:
+	docker-compose build
+
 install:
 	sudo cp contrib/LAVA.rules /etc/udev/rules.d/
 	sudo cp contrib/usb-passthrough /usr/local/bin/


### PR DESCRIPTION
…images.

The motivation to introduce such a target was to e.g. download and cache big
files locally before building images. That feature isn't realized yet, but
docs already refer to "make build", so let's have it here.