### PR TITLE
docker-compose.yaml: Allow to use docker inside lava-dispatcher.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,10 @@ lava-boards:
 	-lavacli -i $(LAVA_IDENTITY) device-types add musca_a
 	lavacli -i $(LAVA_IDENTITY) device-types template set musca_a device-types/musca_a.jinja2
 
+	-lavacli -i $(LAVA_IDENTITY) device-types add docker
+	-lavacli -i $(LAVA_IDENTITY) devices add --type docker --worker lava-dispatcher docker-01
+	lavacli -i $(LAVA_IDENTITY) devices dict set docker-01 devices/docker-01.jinja2
+
 testjob:
 	lavacli -i dispatcher jobs submit example/micropython-interactive.job
 

--- a/devices/docker-01.jinja2
+++ b/devices/docker-01.jinja2
@@ -1,0 +1,1 @@
+{% extends 'docker.jinja2' %}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -117,6 +117,7 @@ services:
       LOGGER_URL: "tcp://lava-logs:5555"
       MASTER_URL: "tcp://lava-master:5556"
     volumes:
+    - /var/run/docker.sock:/var/run/docker.sock # allow to use docker inside this container
     - /run/udev/control:/run/udev/control:ro # libudev expects it for udev events
     - /boot:/boot:ro
     - /lib/modules:/lib/modules:ro

--- a/example/docker-busybox.job
+++ b/example/docker-busybox.job
@@ -1,0 +1,36 @@
+# A simple job demonstrating how to boot a docker image in LAVA.
+job_name: docker-busybox
+
+device_type: docker
+visibility: public
+
+timeouts:
+  job:
+    seconds: 120
+  action:
+    seconds: 30
+
+actions:
+
+- deploy:
+    to: docker
+    image: busybox
+# When directly specifying "image: <name>", LAVA will try to docker-pull
+# this image to get the latest version. During development, when you
+# know that you already have the latest version locally, you can save
+# a bit on traffic/test execution overhead with:
+#    image:
+#        name: busybox
+#        local: true
+
+- boot:
+    method: docker
+    # Command to execute in container. Can be set to empty string ("") to use
+    # image's default command.
+    command: "ls -l --color=never"
+    prompts:
+    - '/ #'
+
+# This job doesn't have a test section, as it just demonstrates how to
+# boot a docker container, but a realistic test job of course will have it.
+# - test:


### PR DESCRIPTION
So we can use LAVA's docker support (run docker containers on dispatcher,
which in our setup itself runs on docker).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>