### PR TITLE
devices/qemu-zephyr-01: QEMU device using Zephyr's QEMU.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ lava-boards:
 	-lavacli -i $(LAVA_IDENTITY) devices add --type qemu --worker lava-dispatcher qemu-01
 	lavacli -i $(LAVA_IDENTITY) devices dict set qemu-01 devices/qemu-01.jinja2
 
+	-lavacli -i $(LAVA_IDENTITY) devices add --type qemu --worker lava-dispatcher qemu-zephyr-01
+	lavacli -i $(LAVA_IDENTITY) devices dict set qemu-zephyr-01 devices/qemu-zephyr-01.jinja2
+	lavacli -i $(LAVA_IDENTITY) devices tags add qemu-zephyr-01 qemu-zephyr
+
 	-lavacli -i $(LAVA_IDENTITY) device-types add musca_a
 	lavacli -i $(LAVA_IDENTITY) device-types template set musca_a device-types/musca_a.jinja2
 

--- a/devices/qemu-zephyr-01.jinja2
+++ b/devices/qemu-zephyr-01.jinja2
@@ -1,0 +1,16 @@
+{% extends 'qemu.jinja2' %}
+{% set mac_addr = 'DE:AD:BE:EF:06:01' %}
+{% set memory = 1024 %}
+{% set netdevice = 'tap' %}
+{% block qemu_method %}
+        parameters:
+          command:
+            /opt/zephyr-sdk/sysroots/x86_64-pokysdk-linux/usr/bin/qemu-system-{{ arch }}
+          boot_options:
+          options:
+          - "-cpu {{ cpu }}"
+          - "-machine {{ machine }}"
+          - "-vga none -serial mon:stdio -nographic"
+          - "-net nic,{{ model }},macaddr={{ mac_addr }} -net {{netdevice}} -m {{ memory }} -monitor none"
+#          - "-version"
+{% endblock qemu_method %}

--- a/example/micropython-interactive-qemu-zephyr.job
+++ b/example/micropython-interactive-qemu-zephyr.job
@@ -1,0 +1,69 @@
+# This is the same job as "micropython-interactive", but uses device tags
+# to select a virtual QEMU device using QEMU from Zephyr SDK.
+job_name: 'lite-aeolus-micropython-qz #823-2ac65a24'
+
+device_type: 'qemu'
+tags:
+- qemu-zephyr
+
+timeouts:
+  job:
+    seconds: 60
+  action:
+    seconds: 30
+
+priority: medium
+visibility: public
+
+context:
+  arch: arm
+  cpu: cortex-m3
+  machine: lm3s6965evb
+  model: 'model=stellaris'
+  serial: '-serial mon:stdio'
+  vga: '-vga none'
+
+actions:
+- deploy:
+    timeout:
+      seconds: 30
+    to: tmpfs
+    images:
+        zephyr:
+          image_arg: '-kernel {zephyr}'
+          # Originally from http://snapshots.linaro.org/components/kernel/aeolus-2/micropython/pfalcon/zephyr/qemu_cortex_m3/823/zephyr.bin
+          url: 'file:///test-images/qemu_cortex_m3/micropython/zephyr.bin'
+
+- boot:
+    method: qemu
+    timeout:
+      seconds: 10
+
+- test:
+    timeout:
+      seconds: 10
+    # docs: https://staging.validation.linaro.org/static/docs/v2/actions-test.html#interactive
+    interactive:
+    - name: repl
+      prompts: [">>>"]
+      script:
+      # Just wait for prompt
+      - command:
+      - command: "2+2\r\n"
+        successes:
+        - message: "4"
+      - command: "2-3\r\n"
+        successes:
+        - message: "-1"
+
+
+metadata:
+  # For some reason, LAVA doesn't allow to query by real job name,
+  # so we need to duplicate it as metadata.
+  job_name: 'lite-aeolus-micropython'
+  build-url: https://ci.linaro.org/job/lite-aeolus-micropython/PLATFORM=qemu_cortex_m3,ZEPHYR_GCC_VARIANT=zephyr,label=docker-xenial-amd64-13/823/
+  build-log: https://ci.linaro.org/job/lite-aeolus-micropython/PLATFORM=qemu_cortex_m3,ZEPHYR_GCC_VARIANT=zephyr,label=docker-xenial-amd64-13/823/consoleText
+  zephyr-gcc-variant: zephyr
+  platform: qemu_cortex_m3
+  git-url: https://github.com/pfalcon/micropython
+  git-commit: 2ac65a24


### PR DESCRIPTION
An example of making a LAVA QEMU device using QEMU binary at the specific
(non-default) location. This still tries to reuse LAVA's distribution
qemu.jinja2 template and override just required minimum in it (which is
still much, as entire QEMU command line needs to be costructed, but
definitely less than by copying the entire qemu.jinja2).

The device thus gets created with the standard "qemu" device type, but
when creating, it's assigned "qemu-zephyr" tag. Afterwards, this
device can be selected by a test job by adding following directives
to it:

tags:
- qemu-zephyr

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>