### PR TITLE
Upgrade to Lava 2019.11

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 DC_POSTGRES_IMAGE=postgres:11.2-alpine
-DC_SERVER_IMAGE=lavasoftware/lava-server:2019.10
-DC_DISPATCHER_IMAGE=lavasoftware/lava-dispatcher:2019.10
+DC_SERVER_IMAGE=lavasoftware/lava-server:2019.11
+DC_DISPATCHER_IMAGE=lavasoftware/lava-dispatcher:2019.11

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-DC_POSTGRES_IMAGE=postgres:11.2-alpine
+DC_POSTGRES_IMAGE=postgres:12-alpine
 DC_SERVER_IMAGE=lavasoftware/lava-server:2019.11
 DC_DISPATCHER_IMAGE=lavasoftware/lava-dispatcher:2019.11

--- a/lite-lava-dispatcher/Dockerfile
+++ b/lite-lava-dispatcher/Dockerfile
@@ -9,11 +9,12 @@ ENV ZEPHYR_HOST_TOOLS_URL="https://builds.zephyrproject.org/sdk/0.10.3/${ZEPHYR_
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
-	python3-pip libusb-1.0.0 vim && \
-	apt-get -y -t stretch-backports install libudev1 && \
+	python3-pip libusb-1.0.0 vim wget && \
+	apt-get -y install libudev1 && \
 	pip3 install --upgrade setuptools && \
 	pip3 install -U git+https://github.com/mbedmicro/pyOCD && \
 	wget --post-data="accept_license_agreement=accepted&non_emb_ctr=confirmed&submit=Download+software" ${JLINK_URL} -O ${JLINK_DEB} && \
+	apt-get -y install libncurses5 && \
 	dpkg -i ${JLINK_DEB} && \
 	rm ${JLINK_DEB} && \
 	ln -s /opt/SEGGER/JLink/JLinkExe /usr/local/bin && \


### PR DESCRIPTION
This is mostly a straightforward update, cherry-picking upstream commits. However, upstream docker images have upgraded to Debian Buster. It required updates to some package installed on our side.

I've tested this with example/ micropython-interactive.job, micropython-interactive-qemu-zephyr.job, lava.job (frdm_k64f), everything works as expected. Would be nice if other folks tested it with their boards/jobs.
