### PR TITLE
example/docker-busybox: Actually consume and check output.

### DIFF
--- a/example/docker-busybox.job
+++ b/example/docker-busybox.job
@@ -31,6 +31,15 @@ actions:
     prompts:
     - '/ #'
 
-# This job doesn't have a test section, as it just demonstrates how to
-# boot a docker container, but a realistic test job of course will have it.
-# - test:
+- test:
+    timeout:
+      seconds: 15
+
+    monitors:
+    - name: wait-finish
+      # Empty start is ok (will start with the beginning of output)
+      start: ""
+      # Something in the last line of output
+      end: "var"
+      # This is ignored
+      pattern: "__ignored__"


### PR DESCRIPTION
Previously, this job lacked "test" section, and this led to the fact
that the output could be either capture or not. Now add explicit
"test: monitor:" to consume (and effectively, check) the output,
making this a template for very simple, but a test.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>