### PR TITLE
docker-compose: lava-server: Bind ../lava/lava_scheduler_app

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -75,6 +75,9 @@ services:
 #      source: ../lava/lava_server
 #      target: /usr/lib/python3/dist-packages/lava_server
 #    - type: bind
+#      source: ../lava/lava_scheduler_app
+#      target: /usr/lib/python3/dist-packages/lava_scheduler_app
+#    - type: bind
 #      source: ../lava/lava_common
 #      target: /usr/lib/python3/dist-packages/lava_common
     depends_on:


### PR DESCRIPTION
For a case of local development setup, we export ../lava/lava_common
because the common understanding was that it contains schemas used to
validate test action paramters across LAVA server/dispatcher boundary
(so, even if we mostly work on dispatcher changes, if we e.g. add new
action params, we must propagate schema changes back to server, or job
submissions with new params will be rejected).

However, turns out that LAVA has a technical debt due to which some of
job schemas are duplicated in ../lava/lava_scheduler_app. Upstream issue
https://git.lavasoftware.org/lava/lava/issues/358. Until it's fixed
(and it even was closed as "not a priority right now"), we need to
duplicate most of the schema changes to ../lava/lava_scheduler_app,
and export it to the container.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>