### PR TITLE
[WIP] lite-lava-dispatcher: Install and start lava-coordinator.

### DIFF
--- a/lite-lava-dispatcher/Dockerfile
+++ b/lite-lava-dispatcher/Dockerfile
@@ -7,9 +7,11 @@ ENV JLINK_URL="https://www.segger.com/downloads/jlink/${JLINK_DEB}"
 ENV ZEPHYR_HOST_TOOLS="zephyr-sdk-x86_64-hosttools-standalone-0.9.sh"
 ENV ZEPHYR_HOST_TOOLS_URL="https://builds.zephyrproject.org/sdk/0.10.3/${ZEPHYR_HOST_TOOLS}"
 
+COPY lava-coordinator.sh /root/entrypoint.d/
+
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
-	python3-pip libusb-1.0.0 vim wget && \
+	python3-pip libusb-1.0.0 vim wget lava-coordinator && \
 	apt-get -y install libudev1 && \
 	pip3 install --upgrade setuptools && \
 	pip3 install -U git+https://github.com/mbedmicro/pyOCD && \

--- a/lite-lava-dispatcher/lava-coordinator.sh
+++ b/lite-lava-dispatcher/lava-coordinator.sh
@@ -1,0 +1,6 @@
+# LAVA Docker startup script for lava-coordinator.
+# This should be put in /root/entrypoint.d/ and relies on entrypoint.sh
+# processing from official LAVA Docker images.
+
+rm -f /var/run/lava-coordinator.pid
+/usr/bin/lava-coordinator --loglevel=DEBUG


### PR DESCRIPTION
lava-coordinator should be run as a daemon for multinode jobs to work.
While its purpose is to allow (explicit) synchronization between sub-jobs
of a multinode job, it's connected to unconditionally for any multinode
job, and without it, such jobs will fail.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>