### PR TITLE
example/docker-xilinx-qemu-openamp-echo_test: Bump timeouts to 10min.

### DIFF
--- a/example/docker-xilinx-qemu-openamp-echo_test.job
+++ b/example/docker-xilinx-qemu-openamp-echo_test.job
@@ -5,9 +5,9 @@ visibility: public
 
 timeouts:
   job:
-    seconds: 400
+    seconds: 600
   action:
-    seconds: 320
+    seconds: 600
 
 actions:
 
@@ -26,7 +26,7 @@ actions:
 
 - test:
     timeout:
-      seconds: 290
+      seconds: 600
 
     interactive:
     - name: wait_login


### PR DESCRIPTION
Today LAVA is slow re: downloads. As this job wget's a test image during
runtime, no choice as to bump to the timeouts considerably.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>