### PR TITLE
docker-xilinx-qemu-openamp-echo_test.job: Use docker with Internet ac…

### DIFF
--- a/example/docker-xilinx-qemu-openamp-echo_test.job
+++ b/example/docker-xilinx-qemu-openamp-echo_test.job
@@ -1,6 +1,9 @@
 job_name: docker-xilinx-qemu-openamp-echo_test
 
 device_type: docker
+tags:
+- inet
+
 visibility: public
 
 timeouts:


### PR DESCRIPTION
…cess.

As we now have docker instance configured for Zephyr internal network, which
doesn't have inet access.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>