### PR TITLE
Makefile: Assign tags to docker devices, following lite.v.l.o.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,10 @@ lava-boards:
 	-lavacli -i $(LAVA_IDENTITY) device-types add docker
 	-lavacli -i $(LAVA_IDENTITY) devices add --type docker --worker lava-dispatcher docker-01
 	lavacli -i $(LAVA_IDENTITY) devices dict set docker-01 devices/docker-generic.jinja2
+	lavacli -i $(LAVA_IDENTITY) devices tags add docker-01 zephyr-net
 	-lavacli -i $(LAVA_IDENTITY) devices add --type docker --worker lava-dispatcher docker-02
 	lavacli -i $(LAVA_IDENTITY) devices dict set docker-02 devices/docker-generic.jinja2
+	lavacli -i $(LAVA_IDENTITY) devices tags add docker-02 inet
 
 testjob:
 	lavacli -i dispatcher jobs submit example/micropython-interactive.job


### PR DESCRIPTION
Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>