### PR TITLE
lite-lava-dispatcher/Dockerfile: Don't check cert when downloading JLink

### DIFF
--- a/lite-lava-dispatcher/Dockerfile
+++ b/lite-lava-dispatcher/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && \
 	apt-get -y install libudev1 && \
 	pip3 install --upgrade setuptools && \
 	pip3 install -U git+https://github.com/mbedmicro/pyOCD && \
-	wget --post-data="accept_license_agreement=accepted&non_emb_ctr=confirmed&submit=Download+software" ${JLINK_URL} -O ${JLINK_DEB} && \
+	wget --no-check-certificate --post-data="accept_license_agreement=accepted&non_emb_ctr=confirmed&submit=Download+software" ${JLINK_URL} -O ${JLINK_DEB} && \
 	apt-get -y install libncurses5 && \
 	dpkg -i ${JLINK_DEB} && \
 	rm ${JLINK_DEB} && \


### PR DESCRIPTION
Because:

--2020-02-11 18:03:13--  https://www.segger.com/downloads/jlink/JLink_Linux_V650_x86_64.deb
Resolving www.segger.com (www.segger.com)... 78.31.67.95
Connecting to www.segger.com (www.segger.com)|78.31.67.95|:443... connected.
ERROR: cannot verify www.segger.com's certificate, issued by ‘CN=AlphaSSL CA - SHA256 - G2,O=GlobalSign nv-sa,C=BE’:
  Unable to locally verify the issuer's authority.
To connect to www.segger.com insecurely, use `--no-check-certificate'.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>