### PR TITLE
docker-test-images/xilinx-openamp-build: Docker image to build OpenAMP

### DIFF
--- a/docker-test-images/README.md
+++ b/docker-test-images/README.md
@@ -1,0 +1,1 @@
+This directory contains definitions of Docker images used by LITE CI/test jobs.

--- a/docker-test-images/xilinx-openamp-build/.dockerignore
+++ b/docker-test-images/xilinx-openamp-build/.dockerignore
@@ -1,0 +1,7 @@
+# Yocto downloads (cached on host)
+downloads/
+# openamp sources (located on host)
+openamp/
+
+# Result build artifacts which may be copied out of container
+*.qemu-sd

--- a/docker-test-images/xilinx-openamp-build/Dockerfile
+++ b/docker-test-images/xilinx-openamp-build/Dockerfile
@@ -1,0 +1,60 @@
+FROM ubuntu:18.04
+
+# Should match owner of bind mounts on host, the below matches values used
+# on Jenkins x86_64-13 build host.
+ARG UID=1000
+ARG GID=1000
+ARG USERNAME=build
+
+# Build happens in this dir.
+ENV XILINX_SOURCES=/home/$USERNAME/prj
+
+RUN groupadd -g $GID -o $USERNAME
+RUN useradd $USERNAME -u $UID -g $GID -o -m -s /dev/null
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install \
+        curl git gpg python python3 \
+        build-essential \
+        chrpath cpio diffstat gawk texinfo wget \
+        locales \
+        libidn11 \
+        less mc nano iputils-ping && \
+    rm -rf /var/lib/apt/lists/* && \
+    locale-gen en_US.UTF-8
+
+ENV LANG en_US.UTF-8
+
+RUN curl -k https://storage.googleapis.com/git-repo-downloads/repo -o repo && \
+    chmod a+x repo && mv repo /usr/local/bin/
+
+USER $USERNAME
+
+RUN git config --global user.email "build@local" && \
+    git config --global user.name "Automated Build"
+
+RUN mkdir -p $XILINX_SOURCES && cd $XILINX_SOURCES && \
+    repo init -u git://github.com/Xilinx/yocto-manifests.git -b rel-v2019.2 </dev/null
+
+RUN cd $XILINX_SOURCES && repo sync
+
+RUN cd $XILINX_SOURCES && bash -c "source setupsdk"
+
+#RUN cd $XILINX_SOURCES && mkdir -p openamp && cd openamp && \
+#    git clone https://github.com/OpenAMP/open-amp && \
+#    git clone https://github.com/OpenAMP/libmetal && \
+#    git clone https://github.com/Xilinx/embeddedsw
+
+COPY local.conf.append $XILINX_SOURCES/build
+RUN cd $XILINX_SOURCES/build && cat local.conf.append >> conf/local.conf
+
+COPY skip-FIGETBSZ.patch $XILINX_SOURCES/sources/core/
+RUN cd $XILINX_SOURCES/sources/core/ && patch -p1 < skip-FIGETBSZ.patch
+
+RUN cd $XILINX_SOURCES/sources && git clone https://github.com/edmooring/meta-user
+
+RUN cd $XILINX_SOURCES && bash -c "source setupsdk; bitbake-layers add-layer $XILINX_SOURCES/sources/core/../meta-user"
+
+# To build image. Doesn't make sense to put this into image, as it will
+# be ~50GB (and take many hours for docker to create).
+#RUN cd $XILINX_SOURCES && bash -c "source setupsdk; MACHINE=zcu102-zynqmp bitbake openamp-image-minimal"

--- a/docker-test-images/xilinx-openamp-build/local.conf.append
+++ b/docker-test-images/xilinx-openamp-build/local.conf.append
@@ -1,0 +1,17 @@
+
+INHERIT += "externalsrc"
+
+PREFERRED_PROVIDER_virtual/open-amp = "open-amp"
+PREFERRED_PROVIDER_virtual/libmetal = "libmetal"
+EXTERNALSRC_pn-open-amp = "/home/build/prj/openamp/open-amp"
+EXTERNALSRC_pn-libmetal = "/home/build/prj/openamp/libmetal"
+RM_WORK_EXCLUDE += "open-amp"
+RM_WORK_EXCLUDE += "libmetal"
+PREFERRED_PROVIDER_virtual/openamp-fw-echo-testd = "openamp-fw-echo-testd"
+EXTERNALSRC_pn-openamp-fw-echo-testd = "/home/build/prj/openamp/embeddedsw"
+RM_WORK_EXCLUDE += "openamp-fw-echo-testd"
+
+DISTRO_FEATURES_append = " openamp "
+
+IMAGE_INSTALL_append = " open-amp kernel-modules open-amp-demos packagegroup-petalinux-openamp "
+CORE_IMAGE_EXTRA_INSTALL_append = " open-amp kernel-modules open-amp-demos "

--- a/docker-test-images/xilinx-openamp-build/run-yocto-build.sh
+++ b/docker-test-images/xilinx-openamp-build/run-yocto-build.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# This script can be used to build a test SD card image, using Docker Yocto
+# image for OpenAMP.
+#
+
+set -ex
+
+# This must be owned by $UID from Dockerfile.
+mkdir -p downloads
+mkdir -p openamp
+cd openamp
+
+if [ ! -d open-amp ]; then
+    git clone https://github.com/OpenAMP/open-amp
+fi
+if [ ! -d libmetal ]; then
+    git clone https://github.com/OpenAMP/libmetal
+fi
+if [ ! -d embeddedsw ]; then
+    git clone https://github.com/Xilinx/embeddedsw
+fi
+
+cd ..
+
+rm -f xilinx-openamp-build.cid
+
+docker run -it --cidfile xilinx-openamp-build.cid \
+    -v $PWD/downloads:/home/build/prj/build/downloads \
+    -v $PWD/openamp:/home/build/prj/openamp \
+    pfalcon/xilinx-openamp-build:v3 \
+    /bin/bash -c "cd ~/prj; source setupsdk; MACHINE=zcu102-zynqmp bitbake openamp-image-minimal"
+
+cid=$(cat xilinx-openamp-build.cid)
+docker cp -L $cid:/home/build/prj/build/tmp/deploy/images/zcu102-zynqmp/openamp-image-minimal-zcu102-zynqmp.wic.qemu-sd .
+
+
+#docker commit $cid pfalcon/xilinx-openamp-build:v17-built

--- a/docker-test-images/xilinx-openamp-build/skip-FIGETBSZ.patch
+++ b/docker-test-images/xilinx-openamp-build/skip-FIGETBSZ.patch
@@ -1,0 +1,16 @@
+diff --git a/scripts/lib/wic/filemap.py b/scripts/lib/wic/filemap.py
+index abbf958b8c..7edf224291 100644
+--- a/scripts/lib/wic/filemap.py
++++ b/scripts/lib/wic/filemap.py
+@@ -37,8 +37,9 @@ def get_block_size(file_obj):
+     """
+     # Get the block size of the host file-system for the image file by calling
+     # the FIGETBSZ ioctl (number 2).
+-    binary_data = fcntl.ioctl(file_obj, 2, struct.pack('I', 0))
+-    bsize = struct.unpack('I', binary_data)[0]
++#    binary_data = fcntl.ioctl(file_obj, 2, struct.pack('I', 0))
++#    bsize = struct.unpack('I', binary_data)[0]
++    bsize = 0
+     if not bsize:
+         import os
+         stat = os.fstat(file_obj.fileno())


### PR DESCRIPTION
Build an OpenAMP artifact (full-system SD card image) which can be submitted
to LAVA for testing.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>