### PR TITLE
Makefile: lava-user: Better password prompt.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ install:
 lava-setup: lava-user lava-identity lava-boards
 
 lava-user:
-	@echo -n "Input LAVA admin user passwd: "; \
+	@echo -n "Input password for LAVA admin user to be created: "; \
 	read passwd; \
 	test -n "$$passwd" && docker exec -it lava-server lava-server manage users add $(LAVA_USER) --superuser --staff --passwd $$passwd || true
 	@echo


### PR DESCRIPTION
The password prompt as it was before, didn't make clear whether it expects
some existing password, or a new password. Make it clear that it's the
latter case.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>