### PR TITLE
Makefile: lava-boards: Add "zephyr-net" tag for frdm-k64f-01.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ lava-boards:
 	-lavacli -i $(LAVA_IDENTITY) device-types add frdm-k64f
 	-lavacli -i $(LAVA_IDENTITY) devices add --type frdm-k64f --worker lava-dispatcher frdm-k64f-01
 	lavacli -i $(LAVA_IDENTITY) devices dict set frdm-k64f-01 devices/frdm-k64f-01.jinja2
+	lavacli -i $(LAVA_IDENTITY) devices tags add frdm-k64f-01 zephyr-net
+
 	-lavacli -i $(LAVA_IDENTITY) device-types add qemu
 	-lavacli -i $(LAVA_IDENTITY) devices add --type qemu --worker lava-dispatcher qemu-01
 	lavacli -i $(LAVA_IDENTITY) devices dict set qemu-01 devices/qemu-01.jinja2


### PR DESCRIPTION
For compatibility with lite.validation.linaro.org production site, where
only one of boards have networking setup. For local setup, we just mark
the only board with this tag for job definition compatbility.

The tag itself is consistent with a docker board tag added earlier.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>