### PR TITLE
docker-test-images: Add "linaro-lava-net-test" test image.

### DIFF
--- a/docker-test-images/linaro-lava-net-test/Dockerfile
+++ b/docker-test-images/linaro-lava-net-test/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && \
+	DEBIAN_FRONTEND=noninteractive apt-get -y install \
+	    apache2-utils \
+	    curl \
+	    git \
+	    iproute2 \
+	    iputils-ping \
+	    net-tools \
+	    python3 \
+	    wget \
+	&& rm -rf /var/lib/apt/lists/*

--- a/docker-test-images/linaro-lava-net-test/README
+++ b/docker-test-images/linaro-lava-net-test/README
@@ -1,0 +1,10 @@
+This directory contain definition for a "host" docker image used for
+networking testing. It contains various networking tools and utilities
+which are or can be useful for networking testing (not all tools
+installed in the image may be used currently).
+
+A testing process is usually comprised of a multinode LAVA job, where
+this image is booted in a docker "virtual device", to represent a "host"
+side of networking connection, and tools installed in the image are
+used to access an embedded board as a "device under test" (or vice-versa,
+for tests where host is a server and device is a client).


### PR DESCRIPTION
From README:

This directory contain definition for a "host" docker image used for
networking testing. It contains various networking tools and utilities
which are or can be useful for networking testing (not all tools
installed in the image may be used currently).

A testing process is usually comprised of a multinode LAVA job, where
this image is booted in a docker "virtual device", to represent a "host"
side of networking connection, and tools installed in the image are
used to access an embedded board as a "device under test" (or vice-versa,
for tests where host is a server and device is a client).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>