### PR TITLE
zephyr-net-ping-frdm_k64f: Switch to linaro-lava-net-test docker image

### DIFF
--- a/example/zephyr-net-ping-frdm_k64f.job
+++ b/example/zephyr-net-ping-frdm_k64f.job
@@ -63,8 +63,8 @@ actions:
     role: [host]
     to: docker
     image:
-        name: debian:buster
-        local: false
+        name: pfalcon/linaro-lava-net-test:v1
+        #local: true
 
 - boot:
     role: [host]


### PR DESCRIPTION
Based on the idea that there should be a single full-featured docker
image for networking testing.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>