### PR TITLE
linaro-lava-net-test: Update image for big_http_download testing.

### DIFF
--- a/docker-test-images/linaro-lava-net-test/Dockerfile
+++ b/docker-test-images/linaro-lava-net-test/Dockerfile
@@ -1,13 +1,34 @@
 FROM ubuntu:18.04
 
-RUN apt-get update && \
-	DEBIAN_FRONTEND=noninteractive apt-get -y install \
-	    apache2-utils \
-	    curl \
-	    git \
-	    iproute2 \
-	    iputils-ping \
-	    net-tools \
-	    python3 \
-	    wget \
-	&& rm -rf /var/lib/apt/lists/*
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update
+
+# Workaround for shared-mime-info hanging (== running
+# *very* slowly) in postinstall script in docker.
+RUN apt-get download shared-mime-info && \
+    dpkg --unpack shared-mime-info*.deb && \
+    rm -f /var/lib/dpkg/info/shared-mime-info.postinst && \
+    apt-get install -y -f
+
+RUN apt-get -y install \
+    apache2-utils \
+    curl \
+    git \
+    iproute2 \
+    iputils-ping \
+    mc \
+    net-tools \
+    python3 \
+    telnet \
+    wget
+
+RUN apt-get -y install \
+    apache2
+
+# Prepare test file for Zephyr's big_http_download sample.
+RUN mkdir -p /var/www/html/static && \
+    cd /var/www/html/static && \
+    wget http://archive.ubuntu.com/ubuntu/dists/xenial/main/installer-amd64/current/images/hd-media/vmlinuz
+
+EXPOSE 80


### PR DESCRIPTION
Install Apache HTTP server and some other utils. Cache a test file
expected by big_http_download sample.

During work on this docker image, a severe slowness was detected,
the build process didn't complete in 30 mins, apparently hanging
while installing shared-mime-info package. The changes contain
workarounds for this (with them, the process completes in some
20 minutes, which is still *very* slow.)

This git pushed to DocketHub as pfalcon/linaro-lava-net-test:v2.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>