### PR TITLE
devices/docker-01: Export HTTP port from container to host.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ lava-boards:
 
 	-lavacli -i $(LAVA_IDENTITY) device-types add docker
 	-lavacli -i $(LAVA_IDENTITY) devices add --type docker --worker lava-dispatcher docker-01
-	lavacli -i $(LAVA_IDENTITY) devices dict set docker-01 devices/docker-generic.jinja2
+	lavacli -i $(LAVA_IDENTITY) devices dict set docker-01 devices/docker-01.jinja2
 	lavacli -i $(LAVA_IDENTITY) devices tags add docker-01 zephyr-net
 	-lavacli -i $(LAVA_IDENTITY) devices add --type docker --worker lava-dispatcher docker-02
 	lavacli -i $(LAVA_IDENTITY) devices dict set docker-02 devices/docker-generic.jinja2

--- a/devices/docker-01.jinja2
+++ b/devices/docker-01.jinja2
@@ -1,0 +1,4 @@
+{% extends 'docker.jinja2' %}
+{# Allow to run HTTP server inside, and access from DUT via port 8980. #}
+{# Extra spaces are workaround for https://git.lavasoftware.org/lava/lava/-/issues/384, to be fixed in LAVA 2020.04 #}
+{% set docker_extra_arguments = [" --publish ", "8980:80 "] %}


### PR DESCRIPTION
docker-01 is tagged as "zephyr-net", and intended to run host-side tools
useful for networking testing. One of such tools is an HTTP server, so
export container's HTTP port at host port 8980, so DUT can access it.
(Port number is chosen to not be commonly used "local development" port.)

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>