### PR TITLE
Upgrade to LAVA 2020.04

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 DC_POSTGRES_IMAGE=postgres:12-alpine
-DC_SERVER_IMAGE=lavasoftware/lava-server:2020.02
-DC_DISPATCHER_IMAGE=lavasoftware/lava-dispatcher:2020.02
+DC_SERVER_IMAGE=lavasoftware/lava-server:2020.04
+DC_DISPATCHER_IMAGE=lavasoftware/lava-dispatcher:2020.04

--- a/overlays/lava-server/etc/apache2/sites-available/lava-server.conf
+++ b/overlays/lava-server/etc/apache2/sites-available/lava-server.conf
@@ -3,60 +3,24 @@
 <VirtualHost *:80>
     ServerAdmin webmaster@localhost
 
-    Alias /static/ /usr/share/lava-server/static/
     Alias /tmp/ /var/lib/lava/dispatcher/tmp/
-    Alias /favicon.ico /usr/share/lava-server/static/lava_server/images/logo.png
 
     # Let apache2 handle these URIs
-    ProxyPass /static !
     ProxyPass /tmp !
-    ProxyPass /favicon.ico !
     # Send request to Gunicorn
     ProxyPass / http://lava-server:8000/
     ProxyPassReverse / http://lava-server:8000/
     ProxyPreserveHost On
 
-    <IfModule mod_headers.c>
-    AddType application/x-font-woff .woff
-    AddType application/x-font-woff2 .woff2
-    ExpiresActive On
-    ExpiresByType application/javascript "access plus 1 month"
-    ExpiresByType application/x-font-woff "access plus 1 month"
-    ExpiresByType application/x-font-woff2 "access plus 1 month"
-    ExpiresByType image/gif "access plus 1 month"
-    ExpiresByType image/png "access plus 1 month"
-    ExpiresByType text/css "access plus 1 month"
-    Header unset ETag
-    FileETag none
-    </IfModule>
-
-    # Allow serving media, static and other custom files
-    <Directory /usr/share/lava-server/static/lava_server/>
-        Options FollowSymLinks
-        AllowOverride None
-         Require all granted
-    </Directory>
-
     DocumentRoot /usr/share/lava-server/static/lava_server/
 
-    # Make exceptions for static and media.
-    # This allows apache to serve those and offload the application server
-    <Location /static>
-        SetHandler      none
-    </Location>
-
-    # images folder for lava-dispatcher tarballs
-    <Location /images/>
-        SetHandler      none
-    </Location>
     <Directory /var/lib/lava/dispatcher/tmp>
-        Options Indexes
+        Options -Indexes
         Require all granted
         AllowOverride None
-    </Directory>
-
-    <Directory /usr/share/lava-server/static>
-        Require all granted
+        <IfModule mod_php7.c>
+            php_admin_flag engine Off
+        </IfModule>
     </Directory>
 
     LogLevel info


### PR DESCRIPTION
Cherry-picks of upstream commits.

As previously, this includes just those changes which cleanly cherry-pick to our branch (some commits change things not in our branch and were skipped).
