### PR TITLE
zephyr-net-ping-frdm_k64f.job: Define host first.

### DIFF
--- a/example/zephyr-net-ping-frdm_k64f.job
+++ b/example/zephyr-net-ping-frdm_k64f.job
@@ -3,13 +3,13 @@ job_name: zephyr-net-ping
 protocols:
   lava-multinode:
     roles:
-      device:
-        device_type: frdm-k64f
+      host:
+        device_type: docker
         tags:
         - zephyr-net
         count: 1
-      host:
-        device_type: docker
+      device:
+        device_type: frdm-k64f
         tags:
         - zephyr-net
         count: 1


### PR DESCRIPTION
The most interesting output in this job happens on host, so try to rearrange
it to go first in the sequence of multinode subjobs.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>