### PR TITLE
Makefile: lava-boards: Ignore errors when setting frdm-k64f-01 device…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ lava-identity:
 lava-boards:
 	-lavacli -i $(LAVA_IDENTITY) device-types add frdm-k64f
 	-lavacli -i $(LAVA_IDENTITY) devices add --type frdm-k64f --worker lava-dispatcher frdm-k64f-01
-	lavacli -i $(LAVA_IDENTITY) devices dict set frdm-k64f-01 devices/frdm-k64f-01.jinja2
+	-lavacli -i $(LAVA_IDENTITY) devices dict set frdm-k64f-01 devices/frdm-k64f-01.jinja2
 	lavacli -i $(LAVA_IDENTITY) devices tags add frdm-k64f-01 zephyr-net
 
 	-lavacli -i $(LAVA_IDENTITY) device-types add qemu


### PR DESCRIPTION
… dict

The required file, devices/frdm-k64f-01.jinja2, isn't in "lite" branch,
because this file contains per-board config (like USB serial), so should
be created by each developer individually.

But let the "lite" branch work out of the box at least for qemu/docker
devices.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>