### PR TITLE
Makefile: all: Add workaround for sudo passwd prompt in background co…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,10 @@ LAVA_USER = admin
 LAVA_IDENTITY = dispatcher
 
 
+# sudo echo below is guaranteedly get a sudo password prompt and provide input
+# (may be problematic in 2nd command with "&").
 all:
+	sudo echo
 	sudo contrib/udev-forward.py -i lava-dispatcher &
 	docker-compose up
 


### PR DESCRIPTION
…mmand

"sudo foo &" may print out password prompt and wait input in background
(before actually running "foo") and never get it. Instead, start with
running dummy foreground command with sudo, to make sure the password
is cached when running next - background - command.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>