### PR TITLE
Makefile: Add clean-env target to clean host environment for LAVA setup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,13 @@ clean:
 	docker-compose rm -vsf
 	docker volume rm -f lava-server-pgdata lava-server-joboutput lava-server-devices lava-server-health-checks
 
+# Clean host environment to let LAVA setup run w/o issues. As an example,
+# stop ModemManager on Ubuntu, which grabs any new serial device and may
+# interfere with commnication on it.
+clean-env:
+	-sudo service apache2 stop
+	-sudo service ModemManager stop
+
 # Create various board configs for connected board(s). Supposed to be done
 # before "install" target.
 board-configs:


### PR DESCRIPTION
E.g., stop apache2 and ModemManager on Ubuntu.