### PR TITLE
example/multinode-qemu-docker: Multinode test job.

### DIFF
--- a/example/multinode-qemu-docker.job
+++ b/example/multinode-qemu-docker.job
@@ -1,0 +1,81 @@
+# Just a test job which exercises QEMU and Docker devices
+# in a multinode configuration.
+
+job_name: multinode-qemu-docker
+
+protocols:
+  lava-multinode:
+    roles:
+      device:
+        device_type: qemu
+        count: 1
+        context:
+          arch: arm
+          cpu: cortex-m3
+          machine: lm3s6965evb
+          model: 'model=stellaris'
+          serial: '-serial mon:stdio'
+          vga: '-vga none'
+      host:
+        device_type: docker
+        count: 1
+
+timeouts:
+  job:
+    minutes: 3
+  action:
+    minutes: 1
+visibility: public
+
+actions:
+
+- deploy:
+    role: [device]
+    to: tmpfs
+    images:
+        zephyr:
+          image_arg: '-kernel {zephyr}'
+          #url: http://snapshots.linaro.org/components/kernel/aeolus-2/micropython/pfalcon/zephyr/qemu_cortex_m3/923/zephyr.bin
+          url: file:///test-images/qemu_cortex_m3/micropython/zephyr.bin
+
+- boot:
+    role: [device]
+    method: qemu
+
+- test:
+    role: [device]
+    interactive:
+    - name: repl
+      prompts: [">>>"]
+      script:
+      # Just wait for prompt
+      - command:
+
+
+- deploy:
+    role: [host]
+    to: docker
+    image:
+        name: busybox
+        local: true
+
+- boot:
+    role: [host]
+    method: docker
+    command: "sh -c 'sleep 5; ls -l --color=never'"
+    prompts:
+    - '/ #'
+
+- test:
+    role: [host]
+    timeout:
+      seconds: 20
+
+    monitors:
+    - name: host-monitor1
+      start: ""
+      end: "var"
+      pattern: "(?P<result>(__none-such__))"
+      fixupdict:
+        PASS: pass
+        FAIL: fail


### PR DESCRIPTION
This is very basic multinode job, intended to just check that multinode
works (and in this regard, similar to "micropython-interactive.job" aka
"make testjob"). It uses qemu and docker device types, and thus can run
without special hardware setup.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>