### PR TITLE
Backup LAVA.rules and deal with multiple boards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ board-configs:
 	-mv ser2net/ser2net.conf ser2net/ser2net.conf.old
 	touch ser2net/ser2net.conf
 	@echo
+	-mv contrib/LAVA.rules contrib/LAVA.rules.old
 	contrib/make-board-files.sh devices
 
 # Make any preparation steps (currently none) and build docker-compose images.

--- a/contrib/make-board-files.sh
+++ b/contrib/make-board-files.sh
@@ -9,5 +9,5 @@ for ser in $1/*.serial; do
     echo "Processing: $ser"
     devname=$(basename $ser .serial)
     devtype=$(echo $devname | python -c "import sys; print(sys.stdin.readline().rsplit('-', 1)[0])")
-    contrib/board-setup-helper.py -d $(cat $ser) -t $devtype -b $1/$devname.jinja2 -u >contrib/LAVA.rules
+    contrib/board-setup-helper.py -d $(cat $ser) -t $devtype -b $1/$devname.jinja2 -u >>contrib/LAVA.rules
 done


### PR DESCRIPTION
'make board-configs' should backup any existing LAVA.rules file and
append to the file in case multiple boards are connected, otherwise
only the last one would appear in LAVA.rules.

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>