### PR TITLE
devices/qemu-01.jinja2: Don't set netdevice='tap' by default.

### DIFF
--- a/devices/qemu-01.jinja2
+++ b/devices/qemu-01.jinja2
@@ -1,4 +1,6 @@
 {% extends 'qemu.jinja2' %}
 {% set mac_addr = 'DE:AD:BE:EF:05:01' %}
 {% set memory = 1024 %}
-{% set netdevice = 'tap' %}
+{# Configuring tap by default may interfere with running qemu-from-docker. #}
+{# As we currently don't use QEMU for networking, just comment it (but keep handy). #}
+{# {% set netdevice = 'tap' %} #}


### PR DESCRIPTION
This setting was made forward-looking to be able to use qemu for
networking testing. But we don't really use it for that, because
much more configuration would be need for that (and we didn't look
into it yet). But now, the 'tap' setting interferes with using
qemu-from-docker (it complains of missing /dev/net/tun), so disable
it for now, but keep around for when we'll look into it again.

Corresponds to production LAVA change
https://review.linaro.org/c/lava/lava-lab/+/35694

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>