### PR TITLE
docker-compose: Expose more udev for docker test action

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -121,7 +121,7 @@ services:
       MASTER_URL: "tcp://lava-master:5556"
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock # allow to use docker inside this container
-    - /run/udev/control:/run/udev/control:ro # libudev expects it for udev events
+    - /run/udev:/run/udev:ro # libudev expects it for udev events
     - /boot:/boot:ro
     - /lib/modules:/lib/modules:ro
     - ./test-images:/test-images:ro


### PR DESCRIPTION
We need access to /run/udev for the docker test action.  This allows the
lava dispatcher to see the full udev info for a device.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>