### PR TITLE
docker-compose: Add additional dir mount for lava-dispatcher for dev

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -137,6 +137,9 @@ services:
 #    - type: bind
 #      source: ../lava/lava_common
 #      target: /usr/lib/python3/dist-packages/lava_common
+#    - type: bind
+#      source: ../lava/lava_dispatcher_host
+#      target: /usr/lib/python3/dist-packages/lava_dispatcher_host
 
   ser2net:
     container_name: lava-ser2net


### PR DESCRIPTION
The lava-dispatcher code imports somethings from the lava_dispatcher_host
dir, so add it in as part of the dirs we would mount of we are pulling
in a development version of the lava-dispatcher.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>