### PR TITLE
docker-compose.yaml: Mount dispatcher tmp dir for transitive access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ install:
 	sudo cp contrib/LAVA.rules /etc/udev/rules.d/
 	sudo cp contrib/usb-passthrough /usr/local/bin/
 	sudo udevadm control --reload
+	# This dir gets bind-mounted to dispatcher container and sub-containers
+	# it runs, to allow access to downloaded images across them.
+	sudo mkdir -p /var/lib/lava/dispatcher/tmp/
 
 lava-setup: lava-user lava-identity lava-boards
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -125,6 +125,8 @@ services:
     - /boot:/boot:ro
     - /lib/modules:/lib/modules:ro
     - ./test-images:/test-images:ro
+     # should be mounted transitively for transitive container access to downloads
+    - /var/lib/lava/dispatcher/tmp:/var/lib/lava/dispatcher/tmp
       # Example for development
       # If you wanted to point to a local git checkout of lava for development
       # of lava_dispatcher, you can uncomment out the lines below and


### PR DESCRIPTION
For some docker-in-docker scenarios (e.g. qemu-in-docker) sub-containers
needs to access downloaded images which are stored in tmp dir. Due to
the way docker-in-docker functionality works, it should be the same
bind mount across all containers (i.e. dispatcher container and
subcontainers spawned by it). And the way to achieve that is to mount
the same host path into the containers.

For more details, see upstream ticket:
https://git.lavasoftware.org/lava/pkg/docker-compose/-/issues/8

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>