### PR TITLE
devices/qemu-zephyr-01.jinja2: Set netdevice to "user" for now.

### DIFF
--- a/devices/qemu-zephyr-01.jinja2
+++ b/devices/qemu-zephyr-01.jinja2
@@ -1,7 +1,8 @@
 {% extends 'qemu.jinja2' %}
 {% set mac_addr = 'DE:AD:BE:EF:06:01' %}
 {% set memory = 1024 %}
-{% set netdevice = 'tap' %}
+{# {% set netdevice = 'tap' %} #}
+{% set netdevice = 'user' %}
 {% block qemu_method %}
         parameters:
           command:


### PR DESCRIPTION
This is similar to a change done previously qemu-01.jinja2, to make this
device compatible with qemu-from-docker usage. (This device isn't intended
for such a usage, but maybe randomly selected by scheduler nonetheless.
We'll need to use explicit tags going forward, but for now, this is
apparently a least-effort workaround.)

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>