### PR TITLE
Makefile: Use "docker-compose exec" instead of "docker exec".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ lava-setup: lava-user lava-identity lava-boards
 lava-user:
 	@echo -n "Input password for the LAVA 'admin' user to be created: "; \
 	read passwd; \
-	test -n "$$passwd" && docker exec -it lava-server lava-server manage users add $(LAVA_USER) --superuser --staff --passwd $$passwd || true
+	test -n "$$passwd" && docker-compose exec lava-server lava-server manage users add $(LAVA_USER) --superuser --staff --passwd $$passwd || true
 	@echo
 	@echo "Now login with username: admin, passwd: (entered above) at:"
 	@echo "http://$(LAVA_HOST)/accounts/login/?next=/api/tokens/"


### PR DESCRIPTION
docker-compose and docker somehow use different namespaces for the names,
where docker's name is exact and concrete, while docker-compose name is
a logical name, from which a conrete is normally formed by namespacing
the logical name using a docker-compose project directory (so, there
potentially can be different deployments of the same project, residing
in different filesystem directories). It works that way, unless exact
docker name is explicitly overriden.

When we forked lava-docker-compose, it exactly used overriden names. But
later they were dropped. We however didn't (cherry-)pick that name, for
the fear that it may break our setup infra we built on top of the original
project.

So, if anything, this change brings us closer to the setup used in upstream
master, with the intention that we could pick that upstream change later
(and so reduce delta to upstream).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>