### PR TITLE
examples: Add example for running QEMU from a Docker image.

### DIFF
--- a/example/micropython-interactive-docker-qemu.job
+++ b/example/micropython-interactive-docker-qemu.job
@@ -1,0 +1,73 @@
+job_name: 'lite-aeolus-micropython #823-2ac65a24'
+
+device_type: 'qemu'
+
+timeouts:
+  job:
+    seconds: 200
+  action:
+    seconds: 200
+
+priority: medium
+visibility: public
+
+context:
+  arch: arm
+  cpu: cortex-m3
+  machine: lm3s6965evb
+  model: 'model=stellaris'
+  serial: '-serial mon:stdio'
+  vga: '-vga none'
+
+actions:
+- deploy:
+    timeout:
+      seconds: 100
+    to: tmpfs
+    images:
+        zephyr:
+          image_arg: '-kernel {zephyr}'
+          url: http://snapshots.linaro.org/components/kernel/aeolus-2/micropython/pfalcon/zephyr/qemu_cortex_m3/1223/zephyr.bin
+          #url: file:///test-images/qemu_cortex_m3/micropython/zephyr.bin
+
+- boot:
+    method: qemu
+    timeout:
+      seconds: 100
+    docker:
+        image: kevintownsend/lite-qemu5:v1
+        binary: /usr/bin/qemu-system-arm
+
+- test:
+    timeout:
+      # Timeout here includes pulling of docker image from dockerhub.
+      seconds: 100
+    # docs: https://staging.validation.linaro.org/static/docs/v2/actions-test.html#interactive
+    interactive:
+    - name: repl
+      prompts: [">>>"]
+      script:
+      # Just wait for prompt
+      - command:
+      - command: "2+2\r\n"
+        name: 2_plus_2
+        successes:
+        # Should match both end of previous and this line, together with
+        # actual content. Matching for "4" will match "14", "41", etc.
+        - message: "\n4\r"
+      - command: "2-3\r\n"
+        name: 2_minus_3
+        successes:
+        - message: "\n-1\r"
+
+
+metadata:
+  # For some reason, LAVA doesn't allow to query by real job name,
+  # so we need to duplicate it as metadata.
+  job_name: 'lite-aeolus-micropython'
+  build-url: https://ci.linaro.org/job/lite-aeolus-micropython/PLATFORM=qemu_cortex_m3,ZEPHYR_GCC_VARIANT=zephyr,label=docker-xenial-amd64-13/823/
+  build-log: https://ci.linaro.org/job/lite-aeolus-micropython/PLATFORM=qemu_cortex_m3,ZEPHYR_GCC_VARIANT=zephyr,label=docker-xenial-amd64-13/823/consoleText
+  zephyr-gcc-variant: zephyr
+  platform: qemu_cortex_m3
+  git-url: https://github.com/pfalcon/micropython
+  git-commit: 2ac65a24


### PR DESCRIPTION
This example is based on existing micropython-interactive.job, but utilizes
a recent LAVA feature - using QEMU binary from a Docker image (instead of
whatever binary is installed in the dispatcher).

(Besides pulling QEMU from Docker image, this sample also downloads test
binary from URL by default, to simplify testing against production LAVA,
and adjusts various timeouts, as pulling an image from Dockerhub takes
additional time).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>