### PR TITLE
devices/qemu*: Don't hardcode "memory" parameter.

### DIFF
--- a/devices/qemu-01.jinja2
+++ b/devices/qemu-01.jinja2
@@ -1,6 +1,5 @@
 {% extends 'qemu.jinja2' %}
 {% set mac_addr = 'DE:AD:BE:EF:05:01' %}
-{% set memory = 1024 %}
 {# Configuring tap by default may interfere with running qemu-from-docker. #}
 {# As we currently don't use QEMU for networking, just comment it (but keep handy). #}
 {# {% set netdevice = 'tap' %} #}

--- a/devices/qemu-zephyr-01.jinja2
+++ b/devices/qemu-zephyr-01.jinja2
@@ -1,6 +1,5 @@
 {% extends 'qemu.jinja2' %}
 {% set mac_addr = 'DE:AD:BE:EF:06:01' %}
-{% set memory = 1024 %}
 {# {% set netdevice = 'tap' %} #}
 {% set netdevice = 'user' %}
 {% block qemu_method %}
@@ -12,6 +11,6 @@
           - "-cpu {{ cpu }}"
           - "-machine {{ machine }}"
           - "-vga none -serial mon:stdio -nographic"
-          - "-net nic,{{ model }},macaddr={{ mac_addr }} -net {{netdevice}} -m {{ memory }} -monitor none"
+          - "-net nic,{{ model }},macaddr={{ mac_addr }} -net {{ netdevice }} -m {{ memory|default(512) }} -monitor none"
 #          - "-version"
 {% endblock qemu_method %}


### PR DESCRIPTION
Different QEMU machines, and applications running on them, have different
requirements regarding memory. So, don't hardcode a value in a device config,
and instead allow to specify a particular value in a job, in "context:"
dictionary. If none is specified, LAVA default of "512" will be used.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>