### PR TITLE
Makefile: Add a workaround for deploying custom device type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,11 @@ lava-boards:
 
 	-lavacli -i $(LAVA_IDENTITY) device-types add musca_a
 	lavacli -i $(LAVA_IDENTITY) device-types template set musca_a device-types/musca_a.jinja2
+	# Workaround: device-type template should be on both lava-server and lava-master, but currently
+	# ends up only on lava-server after "lavacli device-types template set" above. So, we copy it
+	# to lava-master manually.
+	# Upstream issue: https://git.lavasoftware.org/lava/pkg/docker-compose/-/issues/4
+	docker cp device-types/musca_a.jinja2 lava-master:/etc/lava-server/dispatcher-config/device-types/
 
 	-lavacli -i $(LAVA_IDENTITY) device-types add frdm-k64f
 	-lavacli -i $(LAVA_IDENTITY) devices add --type frdm-k64f --worker lava-dispatcher frdm-k64f-01


### PR DESCRIPTION
When we set a template for custom device type with
"lavacli device-types template set" command, it ends up in one container
on docker-compose system, but actually also expected in others. This is
a known upstream issue tracked as
https://git.lavasoftware.org/lava/pkg/docker-compose/-/issues/4.

We work it around for now by pushing the file manually to "another"
container. Currently, this applies to "musca_a" device type, but care
should be taken to apply the same workaround to other introduced custom
device types.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>