### PR TITLE
Makefile: *-shell: Use "docker-compose exec" instead of "docker exec".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ testjob:
 	lavacli -i $(LAVA_IDENTITY) jobs submit example/micropython-interactive.job
 
 dispatcher-shell:
-	docker exec -it lava-dispatcher bash
+	docker-compose exec lava-dispatcher bash
 
 server-shell:
-	docker exec -it lava-server bash
+	docker-compose exec lava-server bash


### PR DESCRIPTION
Similar to a change previously in another place. Allows us to rely on
docker-compose's logical names (and ultimately, get close to upstream
and run multiple instances of the setup).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>