### PR TITLE
[RFC] Makefile: clean: Use "docker-compose down".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,7 @@ stop:
 
 clean:
 	-sudo pkill udev-forward.py
-	docker-compose rm -vsf
-	docker volume rm -f lava-server-pgdata lava-server-joboutput lava-server-devices lava-server-health-checks
+	docker-compose down -v
 
 # Clean host environment to let LAVA setup run w/o issues. As an example,
 # stop ModemManager on Ubuntu, which grabs any new serial device and may


### PR DESCRIPTION
Instead of removing containers and volumes "manually". The benefit is
avoiding to enumerate which volumes to remove, as their set and names
may change over time.

Another difference of "docket-compose down" is that it also removes
related network interfaces (required for containers, etc. to communicate
among themselves).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>