### PR TITLE
Usb passthrough

### DIFF
--- a/contrib/usb-passthrough
+++ b/contrib/usb-passthrough
@@ -26,6 +26,7 @@ import os
 import sys
 import stat
 import docker
+import pyudev
 
 # Example of what a udev rule looks like for using this script
 #
@@ -42,8 +43,10 @@ def devnode_props(node):
 
     return (dev_type, major, minor)
 
-def pass_device_into_container(instance, node, serial_no, links):
+def pass_device_into_container(instance, dev, serial_no):
     client = docker.from_env()
+
+    node = dev.device_node
 
     container = client.containers.get(instance)
 
@@ -58,7 +61,7 @@ def pass_device_into_container(instance, node, serial_no, links):
                      " " + str(major) + " " + str(minor) + "'"
     container.exec_run(create_dev_cmd)
 
-    for link in links.split():
+    for link in dev.device_links:
         link_cmd = "sh -c 'mkdir -p $(dirname " + link + ");" + \
                 "ln -f -s " + node + " " + link + "'"
         container.exec_run(link_cmd)
@@ -107,22 +110,28 @@ def main():
                         help="Add device")
 
     options = parser.parse_args()
-
-    links = ""
-    if ('DEVLINKS' in os.environ):
-        links = os.environ['DEVLINKS']
-
-    device_node = os.environ['DEVNAME']
-
     if (options.add):
-        pass_device_into_container(options.instance, device_node, options.device_serial, links)
+        context = pyudev.Context()
+        for device in context.list_devices():
+            if device.get("ID_SERIAL_SHORT") == options.device_serial:
+                pass_device_into_container(options.instance, device, options.device_serial)
+
+                for child in device.children:
+                    if child.device_node:
+                        pass_device_into_container(options.instance, child, options.device_serial)
+
     else:
+        links = ""
+        if ('DEVLINKS' in os.environ):
+            links = os.environ['DEVLINKS']
+
         dev_type = "c"
         if (os.environ['SUBSYSTEM'] == "block"):
             dev_type = "b"
 
         major = os.environ['MAJOR']
         minor = os.environ['MINOR']
+        device_node = os.environ['DEVNAME']
 
         remove_device_from_container(options.instance, dev_type, major, minor, device_node, options.device_serial, links)
 

--- a/contrib/usb-passthrough
+++ b/contrib/usb-passthrough
@@ -31,10 +31,23 @@ import docker
 #
 # ACTION=="add", ENV{ID_SERIAL_SHORT}=="E00A1029", RUN+="/usr/local/bin/usb-passthrough -a -d %E{ID_SERIAL_SHORT} -i lava-dispatcher"
 
-def pass_device_into_container(instance, dev_type, major, minor, node, serial_no, subsys, links):
+def devnode_props(node):
+    node_stat = os.stat(node)
+    major = os.major(node_stat.st_rdev)
+    minor = os.minor(node_stat.st_rdev)
+    if stat.S_ISBLK(node_stat.st_mode):
+        dev_type = "b"
+    else:
+        dev_type = "c"
+
+    return (dev_type, major, minor)
+
+def pass_device_into_container(instance, node, serial_no, subsys, links):
     client = docker.from_env()
 
     container = client.containers.get(instance)
+
+    dev_type, major, minor = devnode_props(node)
 
     allow_devices = open("/sys/fs/cgroup/devices/docker/%s/devices.allow" % container.id, "w")
     allow_devices.write("%s %s:%s rwm\n" % (dev_type, major, minor))
@@ -104,17 +117,18 @@ def main():
     if ('DEVLINKS' in os.environ):
         links = os.environ['DEVLINKS']
 
-    dev_type = "c"
-    if (subsys == "block"):
-        dev_type = "b"
-
-    major = os.environ['MAJOR']
-    minor = os.environ['MINOR']
     device_node = os.environ['DEVNAME']
 
     if (options.add):
-        pass_device_into_container(options.instance, dev_type, major, minor, device_node, options.device_serial, subsys, links)
+        pass_device_into_container(options.instance, device_node, options.device_serial, subsys, links)
     else:
+        dev_type = "c"
+        if (subsys == "block"):
+            dev_type = "b"
+
+        major = os.environ['MAJOR']
+        minor = os.environ['MINOR']
+
         remove_device_from_container(options.instance, dev_type, major, minor, device_node, options.device_serial, subsys, links)
 
 

--- a/contrib/usb-passthrough
+++ b/contrib/usb-passthrough
@@ -63,10 +63,8 @@ def pass_device_into_container(instance, node, serial_no, subsys, links):
                 "ln -f -s " + node + " " + link + "'"
         container.exec_run(link_cmd)
 
-    udev_file_name = "/etc/udev/rules.d/lava-%s-%s-%s" % (instance, serial_no, subsys)
-    if ('ID_USB_INTERFACE_NUM' in os.environ):
-        udev_file_name += "-if%s" % os.environ['ID_USB_INTERFACE_NUM']
-    udev_file_name += ".rules"
+    sanitize_node = node.replace('/', '-')
+    udev_file_name = "/etc/udev/rules.d/lava-%s-%s%s.rules" % (instance, serial_no, sanitize_node)
 
     udev_rule = open(udev_file_name, "w")
 
@@ -93,10 +91,8 @@ def remove_device_from_container(instance, dev_type, major, minor, node, serial_
         link_cmd = "rm " + link
         container.exec_run(link_cmd)
 
-    udev_file_name = "/etc/udev/rules.d/lava-%s-%s-%s" % (instance, serial_no, subsys)
-    if ('ID_USB_INTERFACE_NUM' in os.environ):
-        udev_file_name += "-if%s" % os.environ['ID_USB_INTERFACE_NUM']
-    udev_file_name += ".rules"
+    node = node.replace('/', '-')
+    udev_file_name = "/etc/udev/rules.d/lava-%s-%s%s.rules" % (instance, serial_no, node)
 
     os.remove(udev_file_name)
 

--- a/contrib/usb-passthrough
+++ b/contrib/usb-passthrough
@@ -42,7 +42,7 @@ def devnode_props(node):
 
     return (dev_type, major, minor)
 
-def pass_device_into_container(instance, node, serial_no, subsys, links):
+def pass_device_into_container(instance, node, serial_no, links):
     client = docker.from_env()
 
     container = client.containers.get(instance)
@@ -76,7 +76,7 @@ def pass_device_into_container(instance, node, serial_no, subsys, links):
 
     udev_rule.close()
 
-def remove_device_from_container(instance, dev_type, major, minor, node, serial_no, subsys, links):
+def remove_device_from_container(instance, dev_type, major, minor, node, serial_no, links):
     client = docker.from_env()
 
     container = client.containers.get(instance)
@@ -108,7 +108,6 @@ def main():
 
     options = parser.parse_args()
 
-    subsys = os.environ['SUBSYSTEM']
     links = ""
     if ('DEVLINKS' in os.environ):
         links = os.environ['DEVLINKS']
@@ -116,16 +115,16 @@ def main():
     device_node = os.environ['DEVNAME']
 
     if (options.add):
-        pass_device_into_container(options.instance, device_node, options.device_serial, subsys, links)
+        pass_device_into_container(options.instance, device_node, options.device_serial, links)
     else:
         dev_type = "c"
-        if (subsys == "block"):
+        if (os.environ['SUBSYSTEM'] == "block"):
             dev_type = "b"
 
         major = os.environ['MAJOR']
         minor = os.environ['MINOR']
 
-        remove_device_from_container(options.instance, dev_type, major, minor, device_node, options.device_serial, subsys, links)
+        remove_device_from_container(options.instance, dev_type, major, minor, device_node, options.device_serial, links)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Updates to usb-passthrough script to match the set of devices expected by lava docker action.

The lava code uses pyudev to determine what device nodes should be passed to a container.  We need to pass the same set of device nodes in usb-passthrough so we match the logic there.