### PR TITLE
example/lava-docker: example job for using a docker shell for testing

### DIFF
--- a/example/lava-docker.job
+++ b/example/lava-docker.job
@@ -1,0 +1,53 @@
+# Zephyr JOB definition for frdm-k64f
+device_type: 'frdm-k64f'
+job_name: 'zephyr docker'
+
+timeouts:
+  job:
+    minutes: 3
+  action:
+    minutes: 3
+  actions:
+    wait-usb-device:
+      seconds: 40
+
+priority: medium
+visibility: public
+
+actions:
+
+- test:
+    docker:
+        image: kumargala/ci-run
+        wait:
+          device: false
+
+    definitions:
+    - repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: kumar
+        run:
+          steps:
+          - ls -lsR /dev
+          - export
+          - pyocd list
+          - lava-test-case test5 --result pass
+          - lava-test-case test6 --result fail
+          - echo "<LAVA_SIGNAL_STARTTC ztest-1>"
+          - echo "foobar"
+          - echo "<LAVA_SIGNAL_ENDTC ztest-1>"
+          - echo "<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=ztest-1 RESULT=safskip>"
+          - wget -q https://people.linaro.org/~kumar.gala/zephyr-sanitycheck-hw.tar.gz
+          - tar xf zephyr-sanitycheck-hw.tar.gz
+          - cd zephyr
+          - west init -l
+          - west config zephyr.base zephyr
+          - ./scripts/sanitycheck -i -p frdm_k64f --device-testing --device-serial /dev/ttyACM0 --test-only --west-flash
+
+      from: inline
+      name: smoke-tests-inline
+      path: inline/smoke-tests-basic.yaml
+
+    timeout:
+      minutes: 2


### PR DESCRIPTION
*** WIP ***

Hacky wip job that uses a docker shell w/a MCU board (frdm-k64f) to run
a slimmed down zephyr testsuite.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>