### PR TITLE
example/zephyr-net-*: Remove "delay" workarounds.

### DIFF
--- a/example/zephyr-net-http-ab-frdm_k64f.job
+++ b/example/zephyr-net-http-ab-frdm_k64f.job
@@ -51,8 +51,6 @@ actions:
       - command:
         name: result
       - lava-send: booted
-      # TODO: delay is workaround for https://git.lavasoftware.org/lava/lava/-/issues/429
-      - delay: 190
       - lava-wait: done
 
 

--- a/example/zephyr-net-ping-frdm_k64f.job
+++ b/example/zephyr-net-ping-frdm_k64f.job
@@ -58,10 +58,6 @@ actions:
 #      - command:
 #        name: result
       - lava-send: booted
-      # Stay around until the other side completes its actions
-      # "delay" is needed because lava-wait's timeout is 30s, which is
-      # too little
-      - delay: 30
       - lava-wait: done
 
 


### PR DESCRIPTION
The underlying issue with too short, non-adjustastable timeout for
"lava-wait" (https://git.lavasoftware.org/lava/lava/-/issues/429)
was fixed in LAVA 2020.08.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>