### PR TITLE
zephyr-net-big_http_download-frdm_k64f: Replace "sleep" with multinod…

### DIFF
--- a/example/zephyr-net-big_http_download-frdm_k64f.job
+++ b/example/zephyr-net-big_http_download-frdm_k64f.job
@@ -50,6 +50,7 @@ actions:
       script:
       - command:
         name: result
+      - lava-send: done
 
 
 - deploy:
@@ -80,5 +81,4 @@ actions:
       # Just to check that local address has expected IP
       - command: "ip address"
       - command: "service apache2 start"
-      # Wait for device to boot
-      - command: "sleep 1200"
+      - lava-wait: done


### PR DESCRIPTION
…e sync

As fully supported and working as expected in LAVA 2020.08.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>