### PR TITLE
example/lava.job: Update test start pattern

### DIFF
--- a/example/lava.job
+++ b/example/lava.job
@@ -33,7 +33,7 @@ actions:
       minutes: 2
     monitors:
     - name: 'tests-subsys-logging-log_list-logging-log_list-zephyr'
-      start: (tc_start\(\)|starting .*test|BOOTING ZEPHYR OS)
+      start: (tc_start\(\)|starting .*test|Booting Zephyr OS)
       end: PROJECT EXECUTION
       pattern: (?P<result>(PASS|FAIL))\s-\s(?P<test_case_id>\w+)\r\n
       fixupdict:


### PR DESCRIPTION
The test pattern on which we actually relied was "BOOTING ZEPHYR OS",
but quite some time ago that was changed upstream to "Booting Zephyr OS".

In this case, other start patterns matched, but the whole matching
was mis-synchronized, e.g. individual testcases weren't matched properly.

The whole match patterns need to be cleaned up, but that should be done
in concert with production CI patterns, so for now just apply quick fix.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>