### PR TITLE
lite-lava-dispatcher: bump tool version

### DIFF
--- a/lite-lava-dispatcher/Dockerfile
+++ b/lite-lava-dispatcher/Dockerfile
@@ -2,10 +2,10 @@ ARG image
 
 FROM ${image}
 
-ENV JLINK_DEB="JLink_Linux_V650_x86_64.deb"
+ENV JLINK_DEB="JLink_Linux_V688a_x86_64.deb"
 ENV JLINK_URL="https://www.segger.com/downloads/jlink/${JLINK_DEB}"
 ENV ZEPHYR_HOST_TOOLS="zephyr-sdk-x86_64-hosttools-standalone-0.9.sh"
-ENV ZEPHYR_HOST_TOOLS_URL="https://builds.zephyrproject.org/sdk/0.10.3/${ZEPHYR_HOST_TOOLS}"
+ENV ZEPHYR_HOST_TOOLS_URL="https://builds.zephyrproject.org/sdk/0.11.4/${ZEPHYR_HOST_TOOLS}"
 
 COPY lava-coordinator.sh /root/entrypoint.d/
 


### PR DESCRIPTION
Update jlink to 6.88a and zephyr-sdk to 0.11.4

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>