### PR TITLE
example/micropython-interactive*: Make jobname match filename

### DIFF
--- a/example/micropython-interactive-qemu-zephyr.job
+++ b/example/micropython-interactive-qemu-zephyr.job
@@ -1,6 +1,6 @@
 # This is the same job as "micropython-interactive", but uses device tags
 # to select a virtual QEMU device using QEMU from Zephyr SDK.
-job_name: 'lite-aeolus-micropython-qz #823-2ac65a24'
+job_name: 'micropython-interactive-qemu-zephyr.job'
 
 device_type: 'qemu'
 tags:

--- a/example/micropython-interactive.job
+++ b/example/micropython-interactive.job
@@ -1,4 +1,4 @@
-job_name: 'lite-aeolus-micropython #823-2ac65a24'
+job_name: 'micropython-interactive.job'
 
 device_type: 'qemu'
 


### PR DESCRIPTION
This follows https://github.com/Linaro/lite-lava-docker-compose/pull/124, and roughly follows naming of other jobs.

The motivation is batch-style "sanity check", where a bunch of jobs are submitted at once, so it was clear which job is which.