### PR TITLE
example/multinode-*: Increase timeout.

### DIFF
--- a/example/multinode-2-dockers-sync.job
+++ b/example/multinode-2-dockers-sync.job
@@ -36,7 +36,7 @@ actions:
 - test:
     role: [docker1]
     timeout:
-      seconds: 30
+      seconds: 50
 
     interactive:
     - name: boot
@@ -71,7 +71,7 @@ actions:
 - test:
     role: [docker2]
     timeout:
-      seconds: 40
+      seconds: 50
 
     interactive:
     - name: boot

--- a/example/multinode-qemu-docker.job
+++ b/example/multinode-qemu-docker.job
@@ -69,7 +69,7 @@ actions:
 - test:
     role: [host]
     timeout:
-      seconds: 20
+      seconds: 30
 
     monitors:
     - name: host-monitor1


### PR DESCRIPTION
These test can run on overloaded systems, and also Docker itself is known
to haev episodes of explainable slow performance, where systems is seemingly
not overloaded, but things in containers run slower than usual.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>