### PR TITLE
docker-compose.yaml: ser2net: Reduce port range exported to the host.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -193,7 +193,7 @@ services:
     ports:
       - 7101:7101
       # LITE devices port range
-      - 5000-5099:5000-5099
+      - 5000-5036:5000-5036
     networks:
       default:
         aliases:


### PR DESCRIPTION
5000-5099 is 100 ports, and that range can be occupied by other services
on localhost. For example, 5037 is the default port for Android adbd.
The larger the range, the higher chance of conflict. 10 ports/devices
should be more than enough for a typical local LAVA deployment. (And
if more needed, that can be extended as part of private config, similar
to board serials, etc.)

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>