### PR TITLE
example/zephyr-net-*: More reliably match Zephyr "booting" line.

### DIFF
--- a/example/zephyr-net-big_http_download-frdm_k64f.job
+++ b/example/zephyr-net-big_http_download-frdm_k64f.job
@@ -40,7 +40,8 @@ actions:
         seconds: 1200
     interactive:
     - name: 1_zephyr_banner
-      prompts: ["Booting Zephyr OS"]
+      # Experience shows that initial chars of the "Booting" message may be received garbled.
+      prompts: ["ng Zephyr OS build.+?\n"]
       script:
       # Just wait for prompt
       - command:

--- a/example/zephyr-net-http-ab-frdm_k64f.job
+++ b/example/zephyr-net-http-ab-frdm_k64f.job
@@ -40,7 +40,8 @@ actions:
         seconds: 250
     interactive:
     - name: 1_zephyr_banner
-      prompts: ["Booting Zephyr OS"]
+      # Experience shows that initial chars of the "Booting" message may be received garbled.
+      prompts: ["ng Zephyr OS build.+?\n"]
       script:
       # Just wait for prompt
       - command:

--- a/example/zephyr-net-ping-frdm_k64f.job
+++ b/example/zephyr-net-ping-frdm_k64f.job
@@ -40,7 +40,8 @@ actions:
         seconds: 70
     interactive:
     - name: 1_zephyr_banner
-      prompts: ["Booting Zephyr OS"]
+      # Experience shows that initial chars of the "Booting" message may be received garbled.
+      prompts: ["ng Zephyr OS build.+?\n"]
       script:
       # Just wait for prompt
       - command:


### PR DESCRIPTION
Serveral initial characters after booting a board may come in garbled. So,
avoid matching by the "Booting Zephyr ..." content, match by "ng Zephyr ...".

Also, match until the end of line, this leads to more logical log output
(first device input is shown, and then "prompt" matched message, and not
vice-versa).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>