### PR TITLE
tfm-regression-qemu.job: Capture both unique test ID and description

### DIFF
--- a/example/tfm-regression-qemu.job
+++ b/example/tfm-regression-qemu.job
@@ -51,7 +51,15 @@ actions:
       start: "Secure image initializing"
       # Something in the last line of output
       end: "End of Non-secure test suites"
-      pattern: "Description: '(?P<test_case_id>.+?)'.+? TEST (?P<result>(PASSED|FAILED))!"
+      # <test_case_id> will capture static word "description", but at least
+      # we'll capture both both TF-M unique test ID and human-readable description.
+      # A tescase id after LAVA's cleanup will look like:
+      # tfm_sst_test_1007_description_get_interface_with_invalid_uids
+      # Note that non-greedy repetitions must be used here (and anywhere else
+      # in LAVA patterns in general), see
+      # https://github.com/Linaro/squad/issues/925#issuecomment-739141313
+      # for details.
+      pattern: "Executing '(?P<test_case_id>.+?'.+?'.+?)'.+? TEST (?P<result>(PASSED|FAILED))!"
       fixupdict:
         PASSED: pass
         FAILED: fail


### PR DESCRIPTION
SQUAD cannot handle duplicate testcase names (while LAVA can),
https://github.com/Linaro/squad/issues/925. An easy fix would be to
switch to use TF-M's testcase IDs as LAVA testcase names, but those
aren't human-readable, so seeing a testcase (among ~170 other) won't
tell you much without digging into source code. So, we hold onto
keeping human-readable description, and capture both, even though that
makes the testcase longish, with a static word "description" repeated
thru each. An example of a testcase name now:

tfm_sst_test_2009_description_get_interface_with_invalid_data_lengths_and_offsets

Thanks to Milosz Wasilewski for suggesting this approach.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>