### PR TITLE
micropython-interactive.job: Reference non-expiring binary link.

### DIFF
--- a/example/micropython-interactive.job
+++ b/example/micropython-interactive.job
@@ -27,7 +27,7 @@ actions:
     images:
         zephyr:
           image_arg: '-kernel {zephyr}'
-          #url: http://snapshots.linaro.org/components/kernel/aeolus-2/micropython/pfalcon/zephyr/qemu_cortex_m3/923/zephyr.bin
+          #url: http://snapshots.linaro.org/components/kernel/aeolus-2/micropython/pfalcon/zephyr/qemu_cortex_m3/latest/zephyr.bin
           url: file:///test-images/qemu_cortex_m3/micropython/zephyr.bin
 
 - boot:


### PR DESCRIPTION
All binary builds eventually expire are garbage-collected. So, just use
"latest" link instead. (A minor risk is that the latest binary may be
broken, the whole idea of using a specific build was that it was actually
tested to work. But there's always some drawbacks, one way ot another.)

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>