### PR TITLE
example/lava.job: boot: cmsis-dap: Add "failure_retry: 3".

### DIFF
--- a/example/lava.job
+++ b/example/lava.job
@@ -26,6 +26,7 @@ actions:
 
 - boot:
     method: cmsis-dap
+    failure_retry: 3
     timeout:
       minutes: 1
 


### PR DESCRIPTION
This change depends on the cmsis-dap boot action to detect failure
(flashing failure, to be specific). Currently LAVA doesn't do, but
the patch was submitted to do that:
https://git.lavasoftware.org/lava/lava/-/merge_requests/1416

So, proactively add this setting, so it wasn't forgotten later.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>