### PR TITLE
Makefile: ser2net-raspi: A helper target to deploy ser2net config to …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,4 +148,8 @@ dispatcher-shell:
 server-shell:
 	docker-compose exec lava-server bash
 
+ser2net-raspi:
+	scp ser2net/ser2net.conf root@pi-worker01.local:/etc/
+	ssh root@pi-worker01.local service ser2net restart
+
 .PHONY: all dispatcher clean


### PR DESCRIPTION
…RasPi.

The idea is to use the same ser2net config file for both Docker setup and
RasPi worker.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>