### PR TITLE
Makefile: ser2net-raspi: Stop, then start ser2net service.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,6 @@ server-shell:
 
 ser2net-raspi:
 	scp ser2net/ser2net.conf root@pi-worker01.local:/etc/
-	ssh root@pi-worker01.local service ser2net restart
+	ssh root@pi-worker01.local "service ser2net stop; service ser2net start"
 
 .PHONY: all dispatcher clean


### PR DESCRIPTION
systemd manages to error out on "restart" if the service is not running.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>