### PR TITLE
example/zephyr-net-*.job: Use "failure_retry: 3".

### DIFF
--- a/example/zephyr-net-big_http_download-frdm_k64f.job
+++ b/example/zephyr-net-big_http_download-frdm_k64f.job
@@ -33,6 +33,7 @@ actions:
 - boot:
     role: [device]
     method: cmsis-dap
+    failure_retry: 3
 
 - test:
     role: [device]

--- a/example/zephyr-net-http-ab-frdm_k64f.job
+++ b/example/zephyr-net-http-ab-frdm_k64f.job
@@ -33,6 +33,7 @@ actions:
 - boot:
     role: [device]
     method: cmsis-dap
+    failure_retry: 3
 
 - test:
     role: [device]

--- a/example/zephyr-net-ping-frdm_k64f.job
+++ b/example/zephyr-net-ping-frdm_k64f.job
@@ -33,6 +33,7 @@ actions:
 - boot:
     role: [device]
     method: cmsis-dap
+    failure_retry: 3
 
 - test:
     role: [device]


### PR DESCRIPTION
Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>