### PR TITLE
example/zephyr-net-*.job: Switch to pyocd boot method.

### DIFF
--- a/example/zephyr-net-http-ab-frdm_k64f.job
+++ b/example/zephyr-net-http-ab-frdm_k64f.job
@@ -32,7 +32,7 @@ actions:
 
 - boot:
     role: [device]
-    method: cmsis-dap
+    method: pyocd
     failure_retry: 3
 
 - test:

--- a/example/zephyr-net-ping-frdm_k64f.job
+++ b/example/zephyr-net-ping-frdm_k64f.job
@@ -32,7 +32,7 @@ actions:
 
 - boot:
     role: [device]
-    method: cmsis-dap
+    method: pyocd
     failure_retry: 3
 
 - test:


### PR DESCRIPTION
These jobs are used as templates for production zephyr-net CI job, and
current target board (lite-frdm-k64f-02) is flaky with "cmsis-dap" boot
method, in less so with "pyocd".

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>