### PR TITLE
zephyr-net-ping-frdm_k64f.job: Bump test timeout to 90s

### DIFF
--- a/example/zephyr-net-ping-frdm_k64f.job
+++ b/example/zephyr-net-ping-frdm_k64f.job
@@ -80,7 +80,7 @@ actions:
 - test:
     role: [host]
     timeout:
-      seconds: 60
+      seconds: 90
     interactive:
     - name: ping
       prompts: ["/# ", "/ # "]


### PR DESCRIPTION
Test includes multinode sync, which may take extra time depending on the
other node's job.

Case seen: https://validation.linaro.org/scheduler/job/2409329

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>