### PR TITLE
Store original and changed device types in the Linaro LAVA Lab

### DIFF
--- a/device-types/staging.validation.linaro.org/lpcxpresso55s69.jinja2
+++ b/device-types/staging.validation.linaro.org/lpcxpresso55s69.jinja2
@@ -1,0 +1,46 @@
+{# device_type: lpcxpresso55s69 #}
+{% extends 'base.jinja2' %}
+{% set usb_vendor_id = '1366' %}
+{% set usb_product_id = '0105' %}
+{% block body %}
+board_id: '{{ board_id|default('0000000000') }}'
+usb_vendor_id: '{{ usb_vendor_id }}'
+usb_product_id: '{{ usb_product_id }}'
+
+actions:
+  deploy:
+    connections:
+      lxc:
+    methods:
+      lxc:
+      image:
+        parameters:
+
+  boot:
+    connections:
+      serial:
+      lxc:
+      ssh:
+    methods:
+      lxc:
+      pyocd:
+        parameters:
+          command:
+            pyocd-flashtool
+          options:
+          - -d {{ debug|default('debug') }}
+          - -t lpc55s69
+          connect_before_flash: true
+      jlink:
+        parameters:
+          command:
+            JLinkExe
+          address:
+            0x00000000
+          options:
+          - '-device LPC55S69_core0'
+          - '-if SWD'
+          - '-speed auto'
+{% endblock body -%}
+
+{% set device_info = device_info|default([{'board_id': board_id, 'usb_vendor_id': usb_vendor_id, 'usb_product_id': usb_product_id}]) %}

--- a/device-types/staging.validation.linaro.org/lpcxpresso55s69.jinja2
+++ b/device-types/staging.validation.linaro.org/lpcxpresso55s69.jinja2
@@ -26,7 +26,7 @@ actions:
       pyocd:
         parameters:
           command:
-            pyocd-flashtool
+            pyocd-flashtool-0.29.0
           options:
           - -d {{ debug|default('debug') }}
           - -t lpc55s69

--- a/device-types/validation.linaro.org/frdm-k64f.jinja2
+++ b/device-types/validation.linaro.org/frdm-k64f.jinja2
@@ -33,6 +33,7 @@ actions:
           - -d {{ debug|default('debug') }}
           - -t k64f
           - -f 3000000
+          - -O connect_mode=under-reset
       cmsis-dap:
         parameters:
           usb_mass_device: '{{ usb_mass_device|default('/notset') }}'

--- a/device-types/validation.linaro.org/frdm-k64f.jinja2
+++ b/device-types/validation.linaro.org/frdm-k64f.jinja2
@@ -1,0 +1,56 @@
+{# device_type: frdm-k64f #}
+{% extends 'base.jinja2' %}
+{% set usb_vendor_id = '0d28' %}
+{% set usb_product_id = '0204' %}
+{% set device_info = device_info|default([{'board_id': board_id, 'usb_vendor_id': usb_vendor_id, 'usb_product_id': usb_product_id}]) %}
+{% block body %}
+board_id: '{{ board_id|default('0000000000') }}'
+usb_vendor_id: '{{ usb_vendor_id }}'
+usb_product_id: '{{ usb_product_id }}'
+usb_sleep: {{ usb_sleep|default(0) }}
+
+actions:
+  deploy:
+    connections:
+      lxc:
+    methods:
+      lxc:
+      image:
+        parameters:
+
+  boot:
+    connections:
+      serial:
+      lxc:
+      ssh:
+    methods:
+      lxc:
+      pyocd:
+        parameters:
+          command:
+            pyocd-flashtool
+          options:
+          - -d {{ debug|default('debug') }}
+          - -t k64f
+          - -f 3000000
+      cmsis-dap:
+        parameters:
+          usb_mass_device: '{{ usb_mass_device|default('/notset') }}'
+          resets_after_flash: {{ resets_after_flash|default(True) }}
+          {# Allow to set any cmsis-dap parameters in a device dict. #}
+          {% filter indent(width=10) -%}
+          {% block cmsis_dap_params %}{% endblock cmsis_dap_params %}
+          {% endfilter %}
+          {# Next empty line is mandatory (jinja matters). #}
+
+      jlink:
+        parameters:
+          command:
+            JLinkExe
+          address:
+            0x00000000
+          options:
+          - '-device MK64FN1M0xxx12'
+          - '-if SWD'
+          - '-speed 4000'
+{% endblock body -%}


### PR DESCRIPTION
Recently, we've got a need to change device type template in the Lab beyond what's shipped in LAVA releases. These changes either specific to peculiar hardware combinations/issues happening in the Lab, or something which isn't practical to propagate to the LAVA distribution at this time: https://git.lavasoftware.org/lava/lava/-/merge_requests/1481

Ideally, such changes should be tracked via Lab's configuration management system, but I may imagine it may take some time to setup that process, and some changes are experimental (cancelled or flip-flopping) anyway. But given that we have 2nd change like that, I'd like them to be captured and visible via change management process, even via interim solution.

To not create yet another repo which will be forgotten and hard to find later, I propose to track those in the existing repo (which then becomes "catch-all things LAVA/LITE" instead of just "LITE LAVA/docker setup").
