### PR TITLE
Makefile: build: Explicitly pull lavasoftware/lava-dispatcher:latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,9 @@ board-configs:
 # Make any preparation steps (currently none) and build docker-compose images.
 build:
 	docker-compose pull
+	# Explicitly pull dispatcher image FROM which we build our own.
+	# Otherwise docker-compose doesn't do that itself.
+	docker pull lavasoftware/lava-dispatcher:latest
 	docker-compose build
 
 install:


### PR DESCRIPTION
This image is not used by docker-compose.yaml directly. Instead this image
(well, string) is passed as an argument to "build" action, and then used
in FROM statement in Dockerfile. Apparently, under such circumstances,
"docker-compose pull" doesn't get an idea that this image should be pulled
too (as ":latest" is ever-updating tag). This leads to server vs dispatcher
version mismatches (e.g. 2021.05 vs 2021.04post1). So, pull it explicitly
to resolve this situation.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>