### PR TITLE
example/tfm-regression-qemu.job: Update pattern for TF-M 1.3 tests

### DIFF
--- a/example/tfm-regression-qemu.job
+++ b/example/tfm-regression-qemu.job
@@ -59,7 +59,7 @@ actions:
       # in LAVA patterns in general), see
       # https://github.com/Linaro/squad/issues/925#issuecomment-739141313
       # for details.
-      pattern: "Executing '(?P<test_case_id>.+?'.+?'.+?)'.+? TEST (?P<result>(PASSED|FAILED))!"
+      pattern: "Executing '(?P<test_case_id>.+?'.+?'.+?)'.+? TEST: (.+? -) (?P<result>(PASSED|FAILED))!"
       fixupdict:
         PASSED: pass
         FAILED: fail


### PR DESCRIPTION
In TF-M 1.3 (or maybe even 1.2), output format changed a bit (testcase
result line now includes a test name too). Update the regex pattern
correspondingly.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>