### PR TITLE
lite-lava-dispatcher: Don't install lava-coordinator, rely on cointainerized

### DIFF
--- a/lite-lava-dispatcher/Dockerfile
+++ b/lite-lava-dispatcher/Dockerfile
@@ -7,12 +7,13 @@ ENV JLINK_URL="https://www.segger.com/downloads/jlink/${JLINK_DEB}"
 ENV ZEPHYR_HOST_TOOLS="zephyr-sdk-x86_64-hosttools-standalone-0.9.sh"
 ENV ZEPHYR_HOST_TOOLS_URL="https://builds.zephyrproject.org/sdk/0.11.4/${ZEPHYR_HOST_TOOLS}"
 
-COPY lava-coordinator.sh /root/entrypoint.d/
+RUN mkdir -p /etc/lava-coordinator
+COPY lava-coordinator.conf /etc/lava-coordinator/
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
         ${extra_packages} \
-        python3-pip libusb-1.0.0 vim wget lava-coordinator && \
+        python3-pip libusb-1.0.0 vim wget && \
         apt-get -y install libudev1 && \
         pip3 install --upgrade setuptools && \
         pip3 install -U pyocd==0.29.0 && \

--- a/lite-lava-dispatcher/lava-coordinator.conf
+++ b/lite-lava-dispatcher/lava-coordinator.conf
@@ -1,0 +1,6 @@
+{
+    "port": 3079,
+    "blocksize": 4096,
+    "poll_delay": 3,
+    "coordinator_hostname": "lava-coordinator"
+}

--- a/lite-lava-dispatcher/lava-coordinator.sh
+++ b/lite-lava-dispatcher/lava-coordinator.sh
@@ -1,6 +1,0 @@
-# LAVA Docker startup script for lava-coordinator.
-# This should be put in /root/entrypoint.d/ and relies on entrypoint.sh
-# processing from official LAVA Docker images.
-
-rm -f /var/run/lava-coordinator.pid
-/usr/bin/lava-coordinator --loglevel=DEBUG


### PR DESCRIPTION
Installing lava-coordinator via apt was effectively a quick stop-gap
measure to get multinode jobs working in dockerized setup. However,
apt package is quite dated (2020.12 currently) and pulls similarly
dated lava-common package which recently started to actively conflict
with other dispatcher code.

OTOH, the (upstream) docker setup includes a container running
coordinator. And real problem originally was actually getting
a proper coordinator config on the dispatcher, installing the
lava-coordinator package seemed like an easy way to do that.
So, now we stop installing the whole package, and instead
install just the config file pointing to a proper host in the
docker-compose system.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>